### PR TITLE
Resolve #11: Use Func<X, Y> to handle methods with parameters.

### DIFF
--- a/test/Autofac.Extras.AggregateService.Test/AggregateServiceGenericsFixture.cs
+++ b/test/Autofac.Extras.AggregateService.Test/AggregateServiceGenericsFixture.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System;
-using System.Linq;
 using Xunit;
 
 namespace Autofac.Extras.AggregateService.Test
@@ -37,6 +36,18 @@ namespace Autofac.Extras.AggregateService.Test
             var notGeneric = aggregateService.GetResolvedGeneric();
             Assert.NotNull(notGeneric);
             Assert.NotSame(generic, notGeneric);
+        }
+
+        [Fact]
+        public void Method_TooManyParameters()
+        {
+            // Issue #11: A function that takes a generic parameter doesn't use the parameter value.
+            var aggregateService = _container.Resolve<IOpenGenericAggregate>();
+
+            var param = aggregateService.GetOpenGeneric<object>();
+            Assert.NotNull(param);
+
+            Assert.Throws<NotSupportedException>(() => aggregateService.TooManyParameters(param, "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r"));
         }
 
         [Fact]

--- a/test/Autofac.Extras.AggregateService.Test/AggregateServiceGenericsFixture.cs
+++ b/test/Autofac.Extras.AggregateService.Test/AggregateServiceGenericsFixture.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Autofac Project. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using System;
+using System.Linq;
 using Xunit;
 
 namespace Autofac.Extras.AggregateService.Test
@@ -15,6 +17,8 @@ namespace Autofac.Extras.AggregateService.Test
             builder.RegisterAggregateService<IOpenGenericAggregate>();
             builder.RegisterGeneric(typeof(OpenGenericImpl<>))
                 .As(typeof(IOpenGeneric<>));
+            builder.RegisterGeneric(typeof(PassThroughOpenGenericImpl<>))
+                .As(typeof(IPassThroughOpenGeneric<>));
 
             _container = builder.Build();
         }
@@ -30,9 +34,22 @@ namespace Autofac.Extras.AggregateService.Test
             var generic = aggregateService.GetOpenGeneric<object>();
             Assert.NotNull(generic);
 
-            var ungeneric = aggregateService.GetResolvedGeneric();
-            Assert.NotNull(ungeneric);
-            Assert.NotSame(generic, ungeneric);
+            var notGeneric = aggregateService.GetResolvedGeneric();
+            Assert.NotNull(notGeneric);
+            Assert.NotSame(generic, notGeneric);
+        }
+
+        [Fact]
+        public void Method_WithOpenGenericParameter()
+        {
+            // Issue #11: A function that takes a generic parameter doesn't use the parameter value.
+            var aggregateService = _container.Resolve<IOpenGenericAggregate>();
+
+            var param = aggregateService.GetOpenGeneric<object>();
+            Assert.NotNull(param);
+
+            var passThrough = aggregateService.UseOpenGenericParameter(param);
+            Assert.Same(param, passThrough.OpenGeneric);
         }
     }
 }

--- a/test/Autofac.Extras.AggregateService.Test/IOpenGenericAggregate.cs
+++ b/test/Autofac.Extras.AggregateService.Test/IOpenGenericAggregate.cs
@@ -10,5 +10,7 @@ namespace Autofac.Extras.AggregateService.Test
         IOpenGeneric<string> GetResolvedGeneric();
 
         IPassThroughOpenGeneric<T> UseOpenGenericParameter<T>(IOpenGeneric<T> openGeneric);
+
+        IOpenGeneric<T> TooManyParameters<T>(IOpenGeneric<T> a, string b, string c, string d, string e, string f, string g, string h, string i, string j, string k, string l, string m, string n, string o, string p, string q, string r);
     }
 }

--- a/test/Autofac.Extras.AggregateService.Test/IOpenGenericAggregate.cs
+++ b/test/Autofac.Extras.AggregateService.Test/IOpenGenericAggregate.cs
@@ -8,5 +8,7 @@ namespace Autofac.Extras.AggregateService.Test
         IOpenGeneric<T> GetOpenGeneric<T>();
 
         IOpenGeneric<string> GetResolvedGeneric();
+
+        IPassThroughOpenGeneric<T> UseOpenGenericParameter<T>(IOpenGeneric<T> openGeneric);
     }
 }

--- a/test/Autofac.Extras.AggregateService.Test/IPassThroughOpenGeneric.cs
+++ b/test/Autofac.Extras.AggregateService.Test/IPassThroughOpenGeneric.cs
@@ -1,0 +1,10 @@
+// Copyright (c) Autofac Project. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace Autofac.Extras.AggregateService.Test
+{
+    public interface IPassThroughOpenGeneric<T>
+    {
+        IOpenGeneric<T> OpenGeneric { get; }
+    }
+}

--- a/test/Autofac.Extras.AggregateService.Test/PassThroughOpenGenericImpl.cs
+++ b/test/Autofac.Extras.AggregateService.Test/PassThroughOpenGenericImpl.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Autofac Project. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace Autofac.Extras.AggregateService.Test
+{
+    public class PassThroughOpenGenericImpl<T> : IPassThroughOpenGeneric<T>
+    {
+        public PassThroughOpenGenericImpl(IOpenGeneric<T> openGeneric)
+        {
+            OpenGeneric = openGeneric;
+        }
+
+        public IOpenGeneric<T> OpenGeneric { get; }
+    }
+}


### PR DESCRIPTION
Added the test for #11 and, for the case of methods with generic parameters, switched the `ResolvingInterceptor` to dynamically create a `Func<X, Y>` delegate type based on the parameter types and return type for the method, then use that resolved factory for the method backing.

The biggest challenge around generic parameters is that, while you might have `OpenGenericImpl<string>` as a parameter, someone could also do `public class MyClosed : OpenGenericImpl<string>` and pass one of those as the parameter, so you get into type casting and compatibility challenges... which we've already solved in core Autofac. Hence the desire to reuse that logic and not mirror it here.

I didn't add caching for the `Func<X, Y>` type signature; we'd need to add method caching and matching logic something similar to the constructor caching and matching in core Autofac which seemed a little overkill here. It does mean for every method invocation (for methods with generic parameters) it's two resolution calls - one to get the factory, one to get the resolved object. Not sure if that's acceptable, but it seemed the simplest way to add support to for open generic methods/parameters.

I did leave the original logic for methods that _don't_ have generic parameters so it's still reasonably optimal.

Generic return types don't appear to have any impact here, so there was no special requirement or change to handle that.