### PR TITLE
Update build badge from AppVeyor to GitHub Actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Dynamic aggregate service implementation generation for [Autofac](https://autofac.org) via Castle DynamicProxy.
 
-[![Build status](https://ci.appveyor.com/api/projects/status/b3gbs0ary7vesd4c?svg=true)](https://ci.appveyor.com/project/Autofac/autofac-extras-aggregateservice) [![Open in Visual Studio Code](https://open.vscode.dev/badges/open-in-vscode.svg)](https://open.vscode.dev/autofac/Autofac.Extras.AggregateService)
+[![Build status](https://github.com/autofac/Autofac.Extras.AggregateService/actions/workflows/ci.yml/badge.svg?branch=develop)](https://github.com/autofac/Autofac.Extras.AggregateService/actions/workflows/ci.yml) [![Open in Visual Studio Code](https://open.vscode.dev/badges/open-in-vscode.svg)](https://open.vscode.dev/autofac/Autofac.Extras.AggregateService)
 
 Please file issues and pull requests for this package in this repository rather than in the Autofac core repo.
 


### PR DESCRIPTION
## Summary

- Replace AppVeyor build status badge with GitHub Actions CI badge in README

## Test plan

- [x] Badge URL format is correct