### PR TITLE
Convert from Moq to NSubstitute

### DIFF
--- a/test/Autofac.Extras.AggregateService.Test/AggregateServiceFixture.cs
+++ b/test/Autofac.Extras.AggregateService.Test/AggregateServiceFixture.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System;
-using Moq;
+using NSubstitute;
 using Xunit;
 
 namespace Autofac.Extras.AggregateService.Test
@@ -17,7 +17,7 @@ namespace Autofac.Extras.AggregateService.Test
 
         public AggregateServiceFixture()
         {
-            _someDependencyMock = new Mock<ISomeDependency>().Object;
+            _someDependencyMock = Substitute.For<ISomeDependency>();
 
             var builder = new ContainerBuilder();
             builder.RegisterAggregateService<IMyContext>();

--- a/test/Autofac.Extras.AggregateService.Test/AggregateServiceGeneratorFixture.cs
+++ b/test/Autofac.Extras.AggregateService.Test/AggregateServiceGeneratorFixture.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System;
-using Moq;
+using NSubstitute;
 using Xunit;
 
 namespace Autofac.Extras.AggregateService.Test
@@ -14,7 +14,7 @@ namespace Autofac.Extras.AggregateService.Test
         public AggregateServiceGeneratorFixture()
         {
             var builder = new ContainerBuilder();
-            builder.RegisterInstance(new Mock<IMyService>().Object);
+            builder.RegisterInstance(Substitute.For<IMyService>());
             _container = builder.Build();
         }
 

--- a/test/Autofac.Extras.AggregateService.Test/AggregateServiceInheritanceFixture.cs
+++ b/test/Autofac.Extras.AggregateService.Test/AggregateServiceInheritanceFixture.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Autofac Project. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using Moq;
+using NSubstitute;
 using Xunit;
 
 namespace Autofac.Extras.AggregateService.Test
@@ -18,8 +18,8 @@ namespace Autofac.Extras.AggregateService.Test
 
         public AggregateServiceInheritanceFixture()
         {
-            _someDependencyMock = new Mock<ISomeDependency>().Object;
-            _someOtherDependencyMock = new Mock<ISomeOtherDependency>().Object;
+            _someDependencyMock = Substitute.For<ISomeDependency>();
+            _someOtherDependencyMock = Substitute.For<ISomeOtherDependency>();
 
             var builder = new ContainerBuilder();
             builder.RegisterAggregateService<ISubService>();

--- a/test/Autofac.Extras.AggregateService.Test/Autofac.Extras.AggregateService.Test.csproj
+++ b/test/Autofac.Extras.AggregateService.Test/Autofac.Extras.AggregateService.Test.csproj
@@ -29,7 +29,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.0" />
-    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="NSubstitute" Version="5.3.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/test/Autofac.Extras.AggregateService.Test/ContainerBuilderExtensionsFixture.cs
+++ b/test/Autofac.Extras.AggregateService.Test/ContainerBuilderExtensionsFixture.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System;
-using Moq;
+using NSubstitute;
 using Xunit;
 
 namespace Autofac.Extras.AggregateService.Test
@@ -71,7 +71,7 @@ namespace Autofac.Extras.AggregateService.Test
         {
             var builder = new ContainerBuilder();
             builder.RegisterAggregateService<IMyContext>();
-            builder.RegisterInstance(new Mock<IMyService>().Object);
+            builder.RegisterInstance(Substitute.For<IMyService>());
             var container = builder.Build();
 
             var firstInstance = container.Resolve<IMyContext>();


### PR DESCRIPTION
## Summary
- Replace Moq with NSubstitute 5.3.0
- Convert `new Mock<T>().Object` usages to `Substitute.For<T>()`
- Part of cross-repo effort to standardize on NSubstitute

## Test plan
- [x] Build succeeds locally
- [x] All 31 tests pass locally