### PR TITLE
Standardize build metadata and code formatting

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,8 +1,5 @@
-; EditorConfig to support per-solution formatting.
-; Use the EditorConfig VS add-in to make this work.
-; http://editorconfig.org/
-
-; This is the default for the codeline.
+# EditorConfig to support per-solution formatting.
+# http://editorconfig.org/
 root = true
 
 [*]
@@ -10,13 +7,187 @@ indent_style = space
 trim_trailing_whitespace = true
 insert_final_newline = true
 
-; .NET Code - almost, but not exactly, the same suggestions as corefx
-; https://github.com/dotnet/corefx/blob/master/.editorconfig
+# .NET Code
 [*.cs]
 indent_size = 4
 charset = utf-8-bom
 
-; New line preferences
+# .NET project files and MSBuild - match defaults for VS
+[*.{csproj,nuspec,proj,projitems,props,shproj,targets,vbproj,vcxproj,vcxproj.filters,vsixmanifest,vsct}]
+indent_size = 2
+
+# .NET solution files - match defaults for VS
+[*.sln]
+end_of_line = crlf
+indent_style = tab
+
+# .NET XML solution files - match dotnet new sln defaults
+[*.slnx]
+indent_size = 2
+
+
+# Config - match XML and default nuget.config template
+[*.config]
+indent_size = 2
+
+# Resources - match defaults for VS
+[*.resx]
+indent_size = 2
+
+# Static analysis rulesets - match defaults for VS
+[*.ruleset]
+indent_size = 2
+
+# HTML, XML - match defaults for VS
+[*.{cshtml,html,xml}]
+indent_size = 4
+
+# JavaScript and JS mixes - match eslint settings; JSON also matches .NET Core templates
+[*.{js,json,mjs,ts,vue}]
+indent_size = 2
+
+# Markdown - match markdownlint settings
+[*.{md,markdown}]
+indent_size = 2
+
+# PowerShell - match defaults for New-ModuleManifest and PSScriptAnalyzer Invoke-Formatter
+[*.{ps1,psd1,psm1}]
+indent_size = 4
+charset = utf-8-bom
+
+# YAML - match standard YAML like Kubernetes and GitHub Actions
+[*.{yaml,yml}]
+indent_size = 2
+
+# ReStructuredText - standard indentation format from examples
+[*.rst]
+indent_size = 2
+
+#
+# dotnet code style
+#
+[*.cs]
+
+# Sort using and Import directives with System.* appearing first
+dotnet_sort_system_directives_first = true
+dotnet_separate_import_directive_groups = false
+
+# Avoid this. unless absolutely necessary
+dotnet_style_qualification_for_field = false:suggestion
+dotnet_style_qualification_for_property = false:suggestion
+dotnet_style_qualification_for_method = false:suggestion
+dotnet_style_qualification_for_event = false:suggestion
+
+# Use language keywords instead of framework type names for type references
+dotnet_style_predefined_type_for_locals_parameters_members = true:warning
+dotnet_style_predefined_type_for_member_access = true:warning
+
+# Suggest more modern language features when available
+dotnet_style_object_initializer = true:warning
+dotnet_style_collection_initializer = true:warning
+dotnet_style_coalesce_expression = true:warning
+dotnet_style_null_propagation = true:warning
+dotnet_style_explicit_tuple_names = true:warning
+
+# Whitespace options
+dotnet_style_allow_multiple_blank_lines_experimental = false
+
+# Non-private static fields are PascalCase
+dotnet_naming_rule.non_private_static_fields_should_be_pascal_case.severity = warning
+dotnet_naming_rule.non_private_static_fields_should_be_pascal_case.symbols = non_private_static_fields
+dotnet_naming_rule.non_private_static_fields_should_be_pascal_case.style = non_private_static_field_style
+
+dotnet_naming_symbols.non_private_static_fields.applicable_kinds = field
+dotnet_naming_symbols.non_private_static_fields.applicable_accessibilities = public, protected, internal, protected_internal, private_protected
+dotnet_naming_symbols.non_private_static_fields.required_modifiers = static
+
+dotnet_naming_style.non_private_static_field_style.capitalization = pascal_case
+
+# Non-private readonly fields are PascalCase
+dotnet_naming_rule.non_private_readonly_fields_should_be_pascal_case.severity = warning
+dotnet_naming_rule.non_private_readonly_fields_should_be_pascal_case.symbols = non_private_readonly_fields
+dotnet_naming_rule.non_private_readonly_fields_should_be_pascal_case.style = non_private_readonly_field_style
+
+dotnet_naming_symbols.non_private_readonly_fields.applicable_kinds = field
+dotnet_naming_symbols.non_private_readonly_fields.applicable_accessibilities = public, protected, internal, protected_internal, private_protected
+dotnet_naming_symbols.non_private_readonly_fields.required_modifiers = readonly
+
+dotnet_naming_style.non_private_readonly_field_style.capitalization = pascal_case
+
+# Constants are PascalCase
+dotnet_naming_rule.constants_should_be_pascal_case.severity = warning
+dotnet_naming_rule.constants_should_be_pascal_case.symbols = constants
+dotnet_naming_rule.constants_should_be_pascal_case.style = constant_style
+
+dotnet_naming_symbols.constants.applicable_kinds = field, local
+dotnet_naming_symbols.constants.required_modifiers = const
+
+dotnet_naming_style.constant_style.capitalization = pascal_case
+
+# Static fields should be _camelCase
+dotnet_naming_rule.static_fields_should_be_camel_case.severity = warning
+dotnet_naming_rule.static_fields_should_be_camel_case.symbols  = static_fields
+dotnet_naming_rule.static_fields_should_be_camel_case.style    = camel_case_underscore_style
+dotnet_naming_symbols.static_fields.applicable_kinds   = field
+dotnet_naming_symbols.static_fields.required_modifiers = static
+
+dotnet_naming_style.static_field_style.capitalization = camel_case
+
+# Instance fields are camelCase and start with _
+dotnet_naming_rule.instance_fields_should_be_camel_case.severity = warning
+dotnet_naming_rule.instance_fields_should_be_camel_case.symbols = instance_fields
+dotnet_naming_rule.instance_fields_should_be_camel_case.style = instance_field_style
+
+dotnet_naming_symbols.instance_fields.applicable_kinds = field
+
+dotnet_naming_style.instance_field_style.capitalization = camel_case
+dotnet_naming_style.instance_field_style.required_prefix = _
+
+# Locals and parameters are camelCase
+dotnet_naming_rule.locals_should_be_camel_case.severity = warning
+dotnet_naming_rule.locals_should_be_camel_case.symbols = locals_and_parameters
+dotnet_naming_rule.locals_should_be_camel_case.style = camel_case_style
+
+dotnet_naming_symbols.locals_and_parameters.applicable_kinds = parameter, local
+
+dotnet_naming_style.camel_case_style.capitalization = camel_case
+
+# Local functions are PascalCase
+dotnet_naming_rule.local_functions_should_be_pascal_case.severity = warning
+dotnet_naming_rule.local_functions_should_be_pascal_case.symbols = local_functions
+dotnet_naming_rule.local_functions_should_be_pascal_case.style = local_function_style
+
+dotnet_naming_symbols.local_functions.applicable_kinds = local_function
+
+dotnet_naming_style.local_function_style.capitalization = pascal_case
+
+# By default, name items with PascalCase
+dotnet_naming_rule.members_should_be_pascal_case.severity = warning
+dotnet_naming_rule.members_should_be_pascal_case.symbols = all_members
+dotnet_naming_rule.members_should_be_pascal_case.style = pascal_case_style
+
+dotnet_naming_symbols.all_members.applicable_kinds = *
+
+dotnet_naming_style.pascal_case_style.capitalization = pascal_case
+
+# IDE0035: Remove unreachable code
+dotnet_diagnostic.IDE0035.severity = warning
+
+# IDE0036: Order modifiers
+dotnet_diagnostic.IDE0036.severity = warning
+
+# IDE0043: Format string contains invalid placeholder
+dotnet_diagnostic.IDE0043.severity = warning
+
+# IDE0044: Make field readonly
+dotnet_diagnostic.IDE0044.severity = warning
+
+# IDE0055: Fix formatting
+dotnet_diagnostic.IDE0055.severity = warning
+
+# C# code style
+#
+# Newline settings
 csharp_new_line_before_open_brace = all
 csharp_new_line_before_else = true
 csharp_new_line_before_catch = true
@@ -25,90 +196,34 @@ csharp_new_line_before_members_in_object_initializers = true
 csharp_new_line_before_members_in_anonymous_types = true
 csharp_new_line_between_query_expression_clauses = true
 
-; Indentation preferences
+# Indentation preferences
 csharp_indent_block_contents = true
 csharp_indent_braces = false
 csharp_indent_case_contents = true
 csharp_indent_case_contents_when_block = true
 csharp_indent_switch_labels = true
-csharp_indent_labels = one_less_than_current
+csharp_indent_labels = flush_left
 
-; Modifier preferences
-csharp_preferred_modifier_order = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async:suggestion
+# Whitespace options
+# Each of the *_experimental rules has a corresponding IDE* setting.
+csharp_style_allow_embedded_statements_on_same_line_experimental = false
+dotnet_diagnostic.IDE2001.severity = warning
+csharp_style_allow_blank_lines_between_consecutive_braces_experimental = false
+dotnet_diagnostic.IDE2002.severity = warning
+csharp_style_allow_blank_line_after_colon_in_constructor_initializer_experimental = false
+dotnet_diagnostic.IDE2004.severity = warning
+csharp_style_allow_blank_line_after_token_in_conditional_expression_experimental = false
+dotnet_diagnostic.IDE2005.severity = warning
+csharp_style_allow_blank_line_after_token_in_arrow_expression_clause_experimental = false
+dotnet_diagnostic.IDE2006.severity = warning
 
-; Avoid this. unless absolutely necessary
-dotnet_style_qualification_for_field = false:suggestion
-dotnet_style_qualification_for_property = false:suggestion
-dotnet_style_qualification_for_method = false:suggestion
-dotnet_style_qualification_for_event = false:suggestion
+# Prefer "var" everywhere
+dotnet_diagnostic.IDE0007.severity = warning
+csharp_style_var_for_built_in_types = true:warning
+csharp_style_var_when_type_is_apparent = true:warning
+csharp_style_var_elsewhere = true:warning
 
-; Types: use keywords instead of BCL types, using var is fine.
-csharp_style_var_when_type_is_apparent = false:none
-dotnet_style_predefined_type_for_locals_parameters_members = true:suggestion
-dotnet_style_predefined_type_for_member_access = true:suggestion
-
-; Name all constant fields using PascalCase
-dotnet_naming_rule.constant_fields_should_be_pascal_case.severity = suggestion
-dotnet_naming_rule.constant_fields_should_be_pascal_case.symbols  = constant_fields
-dotnet_naming_rule.constant_fields_should_be_pascal_case.style    = pascal_case_style
-dotnet_naming_symbols.constant_fields.applicable_kinds   = field
-dotnet_naming_symbols.constant_fields.required_modifiers = const
-dotnet_naming_style.pascal_case_style.capitalization = pascal_case
-
-; Static fields should be _camelCase
-dotnet_naming_rule.static_fields_should_be_camel_case.severity = suggestion
-dotnet_naming_rule.static_fields_should_be_camel_case.symbols  = static_fields
-dotnet_naming_rule.static_fields_should_be_camel_case.style    = camel_case_underscore_style
-dotnet_naming_symbols.static_fields.applicable_kinds   = field
-dotnet_naming_symbols.static_fields.required_modifiers = static
-dotnet_naming_symbols.static_fields.applicable_accessibilities = private, internal, private_protected
-
-; Static readonly fields should be PascalCase
-dotnet_naming_rule.static_readonly_fields_should_be_pascal_case.severity = suggestion
-dotnet_naming_rule.static_readonly_fields_should_be_pascal_case.symbols  = static_readonly_fields
-dotnet_naming_rule.static_readonly_fields_should_be_pascal_case.style    = pascal_case_style
-dotnet_naming_symbols.static_readonly_fields.applicable_kinds   = field
-dotnet_naming_symbols.static_readonly_fields.required_modifiers = static, readonly
-dotnet_naming_symbols.static_readonly_fields.applicable_accessibilities = private, internal, private_protected
-
-; Internal and private fields should be _camelCase
-dotnet_naming_rule.camel_case_for_private_internal_fields.severity = suggestion
-dotnet_naming_rule.camel_case_for_private_internal_fields.symbols  = private_internal_fields
-dotnet_naming_rule.camel_case_for_private_internal_fields.style    = camel_case_underscore_style
-dotnet_naming_symbols.private_internal_fields.applicable_kinds = field
-dotnet_naming_symbols.private_internal_fields.applicable_accessibilities = private, internal
-dotnet_naming_style.camel_case_underscore_style.required_prefix = _
-dotnet_naming_style.camel_case_underscore_style.capitalization = camel_case
-
-; Code style defaults
-csharp_using_directive_placement = outside_namespace:suggestion
-dotnet_sort_system_directives_first = true
-csharp_prefer_braces = true:refactoring
-csharp_preserve_single_line_blocks = true:none
-csharp_preserve_single_line_statements = false:none
-csharp_prefer_static_local_function = true:suggestion
-csharp_prefer_simple_using_statement = false:none
-csharp_style_prefer_switch_expression = true:suggestion
-
-; Code quality
-dotnet_style_readonly_field = true:suggestion
-dotnet_code_quality_unused_parameters = non_public:suggestion
-
-; Expression-level preferences
-dotnet_style_object_initializer = true:suggestion
-dotnet_style_collection_initializer = true:suggestion
-dotnet_style_explicit_tuple_names = true:suggestion
-dotnet_style_coalesce_expression = true:suggestion
-dotnet_style_null_propagation = true:suggestion
-dotnet_style_prefer_is_null_check_over_reference_equality_method = true:suggestion
-dotnet_style_prefer_inferred_tuple_names = true:suggestion
-dotnet_style_prefer_inferred_anonymous_type_member_names = true:suggestion
-dotnet_style_prefer_auto_properties = true:suggestion
-dotnet_style_prefer_conditional_expression_over_assignment = true:refactoring
-dotnet_style_prefer_conditional_expression_over_return = true:refactoring
-csharp_prefer_simple_default_expression = true:suggestion
-
-# Expression-bodied members
+# Prefer method-like constructs to have a block body
 csharp_style_expression_bodied_methods = true:refactoring
 csharp_style_expression_bodied_constructors = true:refactoring
 csharp_style_expression_bodied_operators = true:refactoring
@@ -118,19 +233,15 @@ csharp_style_expression_bodied_accessors = true:refactoring
 csharp_style_expression_bodied_lambdas = true:refactoring
 csharp_style_expression_bodied_local_functions = true:refactoring
 
-# Pattern matching
-csharp_style_pattern_matching_over_is_with_cast_check = true:suggestion
-csharp_style_pattern_matching_over_as_with_null_check = true:suggestion
-csharp_style_inlined_variable_declaration = true:suggestion
-
-# Null checking preferences
-csharp_style_throw_expression = true:suggestion
-csharp_style_conditional_delegate_call = true:suggestion
-
-# Other features
-csharp_style_prefer_index_operator = false:none
-csharp_style_prefer_range_operator = false:none
-csharp_style_pattern_local_over_anonymous_function = false:none
+# Suggest more modern language features when available
+csharp_style_pattern_matching_over_is_with_cast_check = true:warning
+csharp_style_pattern_matching_over_as_with_null_check = true:warning
+csharp_style_inlined_variable_declaration = true:warning
+csharp_style_throw_expression = true:warning
+csharp_style_conditional_delegate_call = true:warning
+csharp_style_prefer_extended_property_pattern = true:warning
+csharp_style_namespace_declarations = file_scoped:warning
+csharp_style_prefer_parameter_null_checking = false
 
 # Space preferences
 csharp_space_after_cast = false
@@ -156,43 +267,30 @@ csharp_space_between_method_declaration_parameter_list_parentheses = false
 csharp_space_between_parentheses = false
 csharp_space_between_square_brackets = false
 
-; .NET project files and MSBuild - match defaults for VS
-[*.{csproj,nuspec,proj,projitems,props,shproj,targets,vbproj,vcxproj,vcxproj.filters,vsixmanifest,vsct}]
-indent_size = 2
+# Blocks required
+csharp_prefer_braces = true:warning
+csharp_preserve_single_line_blocks = false
+csharp_preserve_single_line_statements = false
 
-; .NET solution files - match defaults for VS
-[*.sln]
-indent_style = tab
+# IDE0011: Add braces
+csharp_prefer_braces = when_multiline:warning
+# NOTE: We need the below severity entry for Add Braces due to https://github.com/dotnet/roslyn/issues/44201
+dotnet_diagnostic.IDE0011.severity = warning
 
-; Config - match XML and default nuget.config template
-[*.config]
-indent_size = 2
+# IDE0040: Add accessibility modifiers
+dotnet_diagnostic.IDE0040.severity = warning
 
-; Resources - match defaults for VS
-[*.resx]
-indent_size = 2
+# IDE0052: Remove unread private member
+dotnet_diagnostic.IDE0052.severity = warning
 
-; Static analysis rulesets - match defaults for VS
-[*.ruleset]
-indent_size = 2
+# IDE0059: Unnecessary assignment to a value
+dotnet_diagnostic.IDE0059.severity = warning
 
-; HTML, XML - match defaults for VS
-[*.{cshtml,html,xml}]
-indent_size = 4
+# IDE0060: Remove unused parameter
+dotnet_diagnostic.IDE0060.severity = warning
 
-; JavaScript and JS mixes - match eslint settings; JSON also matches .NET Core templates
-[*.{js,json,ts,vue}]
-indent_size = 2
+# CA1012: Abstract types should not have public constructors
+dotnet_diagnostic.CA1012.severity = warning
 
-; Markdown - match markdownlint settings
-[*.{md,markdown}]
-indent_size = 2
-
-; PowerShell - match defaults for New-ModuleManifest and PSScriptAnalyzer Invoke-Formatter
-[*.{ps1,psd1,psm1}]
-indent_size = 4
-charset = utf-8-bom
-
-; ReStructuredText - standard indentation format from examples
-[*.rst]
-indent_size = 2
+# CA1822: Make member static
+dotnet_diagnostic.CA1822.severity = warning

--- a/build/Source.ruleset
+++ b/build/Source.ruleset
@@ -4,23 +4,39 @@
   <Rules AnalyzerId="Microsoft.Usage" RuleNamespace="Microsoft.Usage">
     <!-- Implement standard exception constructors - not all of the exception constructors (e.g., parameterless) are desired in our system. -->
     <Rule Id="CA1032" Action="None" />
+    <!-- Avoid excessive inheritance (must be explicitly enabled). -->
+    <Rule Id="CA1501" Action="Warning" />
+    <!-- Avoid excessive complexity (must be explicitly enabled). -->
+    <Rule Id="CA1502" Action="Warning" />
+    <!-- Avoid unmaintainable code (must be explicitly enabled). -->
+    <Rule Id="CA1505" Action="Warning" />
+    <!-- Avoid excessive class coupling (must be explicitly enabled). -->
+    <Rule Id="CA1506" Action="Warning" />
+    <!-- Use ArgumentNullException.ThrowIfNull - this isn't available until we stop targeting netstandard. -->
+    <Rule Id="CA1510" Action="None" />
+    <!-- Use ArgumentOutOfRangeException.ThrowIfNegative - this isn't available until we stop targeting anything below net8.0. -->
+    <Rule Id="CA1512" Action="None" />
+    <!-- Use ObjectDisposedException.ThrowIf - this isn't available until we stop targeting anything below net8.0. -->
+    <Rule Id="CA1513" Action="None" />
     <!-- Change names to avoid reserved word overlaps (e.g., Delegate, GetType, etc.) - too many of these in the public API, we'd break if we fixed it. -->
     <Rule Id="CA1716" Action="None" />
-    <!-- Implement serialization constructors - false positive when building .NET Core -->
+    <!-- Cache a CompositeFormat object for use in String.Format - this isn't available until we stop targeting netstandard, and we only String.Format when throwing exceptions so the work/complexity isn't justified to increase perf just for those situations. -->
+    <Rule Id="CA1863" Action="None" />
+    <!-- Implement serialization constructors - false positive when building .NET Core. -->
     <Rule Id="CA2229" Action="None" />
-    <!-- Mark ISerializable types with SerializableAttribute - false positive when building .NET Core -->
+    <!-- Mark ISerializable types with SerializableAttribute - false positive when building .NET Core. -->
     <Rule Id="CA2237" Action="None" />
+    <!-- Prefer generic overloads to using Type parameters - many aren't available in earlier frameworks; and we do a lot of reflection work in Autofac. -->
+    <Rule Id="CA2263" Action="None" />
   </Rules>
   <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
-    <!-- Prefix local calls with this -->
+    <!-- Prefix local calls with this. -->
     <Rule Id="SA1101" Action="None" />
-    <!-- Use built-in type alias -->
+    <!-- Use built-in type alias. -->
     <Rule Id="SA1121" Action="None" />
-    <!-- Use String.Empty instead of "" -->
+    <!-- Use String.Empty instead of "". -->
     <Rule Id="SA1122" Action="None" />
-    <!-- Using statements must be inside a namespace -->
-    <Rule Id="SA1200" Action="None" />
-    <!-- Fields can't start with underscore -->
+    <!-- Fields can't start with underscore. -->
     <Rule Id="SA1309" Action="None" />
   </Rules>
 </RuleSet>

--- a/build/Test.ruleset
+++ b/build/Test.ruleset
@@ -1,51 +1,92 @@
-<?xml version="1.0" encoding="utf-8"?>
-<RuleSet Name="Autofac Analyzer Rules" Description="Analyzer rules for Autofac test assemblies." ToolsVersion="16.0">
+﻿<?xml version="1.0" encoding="utf-8"?>
+<RuleSet Name="Autofac Analyzer Rules" Description="Analyzer rules for Autofac assemblies." ToolsVersion="16.0">
   <IncludeAll Action="Warning" />
   <Rules AnalyzerId="Microsoft.Usage" RuleNamespace="Microsoft.Usage">
+    <!-- Avoid excessive parameters on generic types (must be explicitly enabled). -->
     <Rule Id="CA1005" Action="Warning" />
+    <!-- Don't catch general exceptions - test scenarios sometimes require general exception handling. -->
     <Rule Id="CA1031" Action="None" />
+    <!-- Implement standard exception constructors - not all of the exception constructors (e.g., parameterless) are desired in our system. -->
     <Rule Id="CA1032" Action="None" />
+    <!-- Avoid empty interfaces - in unit tests for service resolution, this happens a lot. -->
     <Rule Id="CA1040" Action="None" />
+    <!-- Do not pass literals as localized parameters  - tests don't need to localize. -->
     <Rule Id="CA1303" Action="None" />
+    <!-- Avoid excessive inheritance (must be explicitly enabled). -->
     <Rule Id="CA1501" Action="Warning" />
+    <!-- Avoid excessive complexity (must be explicitly enabled). -->
     <Rule Id="CA1502" Action="Warning" />
+    <!-- Avoid unmaintainable code (must be explicitly enabled). -->
     <Rule Id="CA1505" Action="Warning" />
+    <!-- Avoid excessive class coupling (must be explicitly enabled). -->
     <Rule Id="CA1506" Action="Warning" />
+    <!-- Use ArgumentNullException.ThrowIfNull - this isn't available until we stop targeting netstandard. -->
     <Rule Id="CA1510" Action="None" />
+    <!-- Make API types internal - causes problems with tests and test assemblies. -->
     <Rule Id="CA1515" Action="None" />
+    <!-- Remove the underscores from member name - unit test scenarios may use underscores. -->
     <Rule Id="CA1707" Action="None" />
+    <!-- Change names to avoid reserved word overlaps (e.g., Delegate, GetType, etc.) - too many of these in the public API, we'd break if we fixed it. -->
     <Rule Id="CA1716" Action="None" />
+    <!-- Internal class that appears to never be instantiated - lots of false positives here because they're test stubs created by Autofac registrations. -->
     <Rule Id="CA1812" Action="None" />
+    <!-- Change Dispose() to call GC.SuppressFinalize - in tests we don't really care and it can impact readability. -->
     <Rule Id="CA1816" Action="None" />
+    <!-- Mark members static - test methods may not access member data but also can't be static. -->
     <Rule Id="CA1822" Action="None" />
+    <!-- Seal internal types for performance - in tests we don't really care and it gets painful to enforce. -->
     <Rule Id="CA1852" Action="None" />
+    <!-- Prefer static readonly fields over constant array arguments - constant array arguments happen a lot in unit tests for assertions and test setup. -->
     <Rule Id="CA1861" Action="None" />
+    <!-- Cache a CompositeFormat object for use in String.Format - this makes unit tests harder to read, and performance isn't an issue. -->
     <Rule Id="CA1863" Action="None" />
+    <!-- Call ConfigureAwait on tasks - you shouldn't do this in unit test libraries; XUnit has an opposite analyzer. -->
     <Rule Id="CA2007" Action="None" />
+    <!-- Implement serialization constructors - false positive when building .NET Core. -->
     <Rule Id="CA2229" Action="None" />
+    <!-- Use Uri instead of string parameters - strings are easier for testing. -->
     <Rule Id="CA2234" Action="None" />
+    <!-- Mark ISerializable types with SerializableAttribute - false positive when building .NET Core. -->
     <Rule Id="CA2237" Action="None" />
+    <!-- Prefer generic overloads to using Type parameters - we do a lot of reflection work in Autofac that needs to be tested. -->
     <Rule Id="CA2263" Action="None" />
   </Rules>
   <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
+    <!-- Prefix local calls with this. -->
     <Rule Id="SA1101" Action="None" />
+    <!-- Use built-in type alias. -->
     <Rule Id="SA1121" Action="None" />
+    <!-- Use String.Empty instead of "". -->
     <Rule Id="SA1122" Action="None" />
+    <!-- Enforce order of class members by member type - sometimes putting test classes/data by the test helps. -->
     <Rule Id="SA1201" Action="None" />
+    <!-- Enforce order of class members by member visibility - sometimes putting test classes/data by the test helps. -->
     <Rule Id="SA1202" Action="None" />
+    <!-- Enforce order of static vs. non-static members - sometimes putting test classes/data by the test helps. -->
     <Rule Id="SA1204" Action="None" />
+    <!-- Fields can't start with underscore. -->
     <Rule Id="SA1309" Action="None" />
+    <!-- Elements should be documented. -->
     <Rule Id="SA1600" Action="None" />
+    <!-- Partial items should be documented. -->
     <Rule Id="SA1601" Action="None" />
+    <!-- Enumeration items should be documented. -->
     <Rule Id="SA1602" Action="None" />
+    <!-- Parameter should be documented. -->
     <Rule Id="SA1611" Action="None" />
+    <!-- Parameter documentation must be in the right order. -->
     <Rule Id="SA1612" Action="None" />
+    <!-- Return value must be documented. -->
     <Rule Id="SA1615" Action="None" />
+    <!-- Generic type parameters must be documented. -->
     <Rule Id="SA1618" Action="None" />
+    <!-- Don't copy/paste documentation. -->
     <Rule Id="SA1625" Action="None" />
-    <Rule Id="SA1633" Action="None" />
+    <!-- Private member is unused - tests for reflection require members that may not get used. -->
     <Rule Id="IDE0051" Action="None" />
+    <!-- Private member assigned value never read - tests for reflection require values that may not get used. -->
     <Rule Id="IDE0052" Action="None" />
+    <!-- Remove unused parameter - tests for reflection require parameters that may not get used. -->
     <Rule Id="IDE0060" Action="None" />
   </Rules>
 </RuleSet>

--- a/build/stylecop.json
+++ b/build/stylecop.json
@@ -9,6 +9,9 @@
         "licenseName": "MIT"
       },
       "xmlHeader": false
+    },
+    "orderingRules": {
+      "usingDirectivesPlacement": "outsideNamespace"
     }
   }
 }

--- a/default.proj
+++ b/default.proj
@@ -57,8 +57,8 @@
     <Exec Command="dotnet build &quot;%(SolutionFile.FullPath)&quot; -c $(Configuration) /p:Version=$(Version)" />
   </Target>
   <Target Name="Package">
-    <MakeDir Directories="$([System.IO.Path]::Combine($(PackageDirectory),%(PublishProject.Filename)))" />
-    <Exec Command="dotnet pack &quot;%(SolutionFile.FullPath)&quot; -c $(Configuration) --output &quot;$(PackageDirectory)&quot; /p:Version=$(Version)" />
+    <MakeDir Directories="$(PackageDirectory)" />
+    <Exec Command="dotnet pack &quot;%(SourceProject.Identity)&quot; -c $(Configuration) --no-build --output &quot;$(PackageDirectory)&quot; /p:Version=$(Version)" />
   </Target>
   <Target Name="Test">
     <MakeDir Directories="$(LogDirectory)" />

--- a/src/Autofac.Extras.AggregateService/AggregateServiceGenerator.cs
+++ b/src/Autofac.Extras.AggregateService/AggregateServiceGenerator.cs
@@ -5,53 +5,52 @@ using System;
 using System.Reflection;
 using Castle.DynamicProxy;
 
-namespace Autofac.Extras.AggregateService
+namespace Autofac.Extras.AggregateService;
+
+/// <summary>
+/// Generate aggregate service instances from interface types.
+/// </summary>
+public static class AggregateServiceGenerator
 {
+    private static readonly ProxyGenerator _generator = new ProxyGenerator();
+
     /// <summary>
-    /// Generate aggregate service instances from interface types.
+    /// Generate an aggregate service instance that will resolve its types from <paramref name="context"/>.
     /// </summary>
-    public static class AggregateServiceGenerator
+    /// <param name="context">The component context from where types will be resolved.</param>
+    /// <typeparam name="TAggregateServiceInterface">The interface type for the aggregate service.</typeparam>
+    /// <returns>The aggregate service instance.</returns>
+    /// <exception cref="ArgumentException">Thrown if <typeparamref name="TAggregateServiceInterface"/> is not an interface.</exception>
+    public static object CreateInstance<TAggregateServiceInterface>(IComponentContext context)
     {
-        private static readonly ProxyGenerator Generator = new ProxyGenerator();
+        return CreateInstance(typeof(TAggregateServiceInterface), context);
+    }
 
-        /// <summary>
-        /// Generate an aggregate service instance that will resolve its types from <paramref name="context"/>.
-        /// </summary>
-        /// <param name="context">The component context from where types will be resolved.</param>
-        /// <typeparam name="TAggregateServiceInterface">The interface type for the aggregate service.</typeparam>
-        /// <returns>The aggregate service instance.</returns>
-        /// <exception cref="ArgumentException">Thrown if <typeparamref name="TAggregateServiceInterface"/> is not an interface.</exception>
-        public static object CreateInstance<TAggregateServiceInterface>(IComponentContext context)
+    /// <summary>
+    /// Generate an aggregate service instance that will resolve its types from <paramref name="context"/>.
+    /// </summary>
+    /// <param name="interfaceType">The interface type for the aggregate service.</param>
+    /// <param name="context">The component context from where types will be resolved.</param>
+    /// <returns>The aggregate service instance.</returns>
+    /// <exception cref="ArgumentException">Thrown if <paramref name="interfaceType"/> is not an interface.</exception>
+    public static object CreateInstance(Type interfaceType, IComponentContext context)
+    {
+        if (context == null)
         {
-            return CreateInstance(typeof(TAggregateServiceInterface), context);
+            throw new ArgumentNullException(nameof(context));
         }
 
-        /// <summary>
-        /// Generate an aggregate service instance that will resolve its types from <paramref name="context"/>.
-        /// </summary>
-        /// <param name="interfaceType">The interface type for the aggregate service.</param>
-        /// <param name="context">The component context from where types will be resolved.</param>
-        /// <returns>The aggregate service instance.</returns>
-        /// <exception cref="ArgumentException">Thrown if <paramref name="interfaceType"/> is not an interface.</exception>
-        public static object CreateInstance(Type interfaceType, IComponentContext context)
+        if (interfaceType == null)
         {
-            if (context == null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
-
-            if (interfaceType == null)
-            {
-                throw new ArgumentNullException(nameof(interfaceType));
-            }
-
-            if (!interfaceType.GetTypeInfo().IsInterface)
-            {
-                throw new ArgumentException(AggregateServicesResources.TypeMustBeInterface, nameof(interfaceType));
-            }
-
-            var resolverInterceptor = new ResolvingInterceptor(interfaceType, context);
-            return Generator.CreateInterfaceProxyWithoutTarget(interfaceType, resolverInterceptor);
+            throw new ArgumentNullException(nameof(interfaceType));
         }
+
+        if (!interfaceType.GetTypeInfo().IsInterface)
+        {
+            throw new ArgumentException(AggregateServicesResources.TypeMustBeInterface, nameof(interfaceType));
+        }
+
+        var resolverInterceptor = new ResolvingInterceptor(interfaceType, context);
+        return _generator.CreateInterfaceProxyWithoutTarget(interfaceType, resolverInterceptor);
     }
 }

--- a/src/Autofac.Extras.AggregateService/ContainerBuilderExtensions.cs
+++ b/src/Autofac.Extras.AggregateService/ContainerBuilderExtensions.cs
@@ -4,72 +4,71 @@
 using System;
 using System.Reflection;
 
-namespace Autofac.Extras.AggregateService
+namespace Autofac.Extras.AggregateService;
+
+/// <summary>
+/// AggregateService extensions to <see cref="ContainerBuilder"/>.
+/// </summary>
+public static class ContainerBuilderExtensions
 {
     /// <summary>
-    /// AggregateService extensions to <see cref="ContainerBuilder"/>.
+    /// Register <typeparamref name="TInterface"/> as an aggregate service.
     /// </summary>
-    public static class ContainerBuilderExtensions
+    /// <param name="builder">The container builder.</param>
+    /// <typeparam name="TInterface">The interface type to register.</typeparam>
+    /// <exception cref="ArgumentNullException">If <typeparamref name="TInterface"/> is null.</exception>
+    /// <exception cref="ArgumentException">If <typeparamref name="TInterface"/> is not an interface.</exception>
+    public static void RegisterAggregateService<TInterface>(this ContainerBuilder builder)
+        where TInterface : class
     {
-        /// <summary>
-        /// Register <typeparamref name="TInterface"/> as an aggregate service.
-        /// </summary>
-        /// <param name="builder">The container builder.</param>
-        /// <typeparam name="TInterface">The interface type to register.</typeparam>
-        /// <exception cref="ArgumentNullException">If <typeparamref name="TInterface"/> is null.</exception>
-        /// <exception cref="ArgumentException">If <typeparamref name="TInterface"/> is not an interface.</exception>
-        public static void RegisterAggregateService<TInterface>(this ContainerBuilder builder)
-            where TInterface : class
-        {
-            builder.RegisterAggregateService(typeof(TInterface));
-        }
-
-        /// <summary>
-        /// Register <paramref name="interfaceType"/> as an aggregate service.
-        /// </summary>
-        /// <param name="builder">The container builder.</param>
-        /// <param name="interfaceType">The interface type to register.</param>
-        /// <exception cref="ArgumentNullException">If <paramref name="interfaceType"/> is null.</exception>
-        /// <exception cref="ArgumentException">If <paramref name="interfaceType"/> is not an interface.</exception>
-        public static void RegisterAggregateService(this ContainerBuilder builder, Type interfaceType)
-        {
-            if (interfaceType == null)
-            {
-                throw new ArgumentNullException(nameof(interfaceType));
-            }
-
-            if (!interfaceType.GetTypeInfo().IsInterface)
-            {
-                throw new ArgumentException(AggregateServicesResources.TypeMustBeInterface, nameof(interfaceType));
-            }
-
-            if (interfaceType.IsGenericTypeDefinition)
-            {
-                RegisterAggregateServiceAsOpenGeneric(builder, interfaceType);
-            }
-            else
-            {
-                if (interfaceType.ContainsGenericParameters)
-                {
-                    throw new ArgumentException(AggregateServicesResources.InterfaceMayNotContainGenericParameters, nameof(interfaceType));
-                }
-
-                RegisterAggregateServiceAsInstance(builder, interfaceType);
-            }
-        }
-
-        private static void RegisterAggregateServiceAsInstance(ContainerBuilder builder, Type interfaceType) =>
-            builder.Register(c =>
-                    AggregateServiceGenerator.CreateInstance(interfaceType, c.Resolve<IComponentContext>()))
-                .As(interfaceType)
-                .InstancePerDependency();
-
-        private static void RegisterAggregateServiceAsOpenGeneric(ContainerBuilder builder, Type interfaceType) =>
-            builder.RegisterGeneric((c, types) =>
-                    AggregateServiceGenerator.CreateInstance(
-                        interfaceType.MakeGenericType(types),
-                        c.Resolve<IComponentContext>()))
-                .As(interfaceType)
-                .InstancePerDependency();
+        builder.RegisterAggregateService(typeof(TInterface));
     }
+
+    /// <summary>
+    /// Register <paramref name="interfaceType"/> as an aggregate service.
+    /// </summary>
+    /// <param name="builder">The container builder.</param>
+    /// <param name="interfaceType">The interface type to register.</param>
+    /// <exception cref="ArgumentNullException">If <paramref name="interfaceType"/> is null.</exception>
+    /// <exception cref="ArgumentException">If <paramref name="interfaceType"/> is not an interface.</exception>
+    public static void RegisterAggregateService(this ContainerBuilder builder, Type interfaceType)
+    {
+        if (interfaceType == null)
+        {
+            throw new ArgumentNullException(nameof(interfaceType));
+        }
+
+        if (!interfaceType.GetTypeInfo().IsInterface)
+        {
+            throw new ArgumentException(AggregateServicesResources.TypeMustBeInterface, nameof(interfaceType));
+        }
+
+        if (interfaceType.IsGenericTypeDefinition)
+        {
+            RegisterAggregateServiceAsOpenGeneric(builder, interfaceType);
+        }
+        else
+        {
+            if (interfaceType.ContainsGenericParameters)
+            {
+                throw new ArgumentException(AggregateServicesResources.InterfaceMayNotContainGenericParameters, nameof(interfaceType));
+            }
+
+            RegisterAggregateServiceAsInstance(builder, interfaceType);
+        }
+    }
+
+    private static void RegisterAggregateServiceAsInstance(ContainerBuilder builder, Type interfaceType)
+        => builder.Register(c =>
+                AggregateServiceGenerator.CreateInstance(interfaceType, c.Resolve<IComponentContext>()))
+            .As(interfaceType)
+            .InstancePerDependency();
+
+    private static void RegisterAggregateServiceAsOpenGeneric(ContainerBuilder builder, Type interfaceType)
+        => builder.RegisterGeneric((c, types) =>
+                AggregateServiceGenerator.CreateInstance(
+                    interfaceType.MakeGenericType(types),
+                    c.Resolve<IComponentContext>()))
+            .As(interfaceType)
+            .InstancePerDependency();
 }

--- a/src/Autofac.Extras.AggregateService/ResolvingInterceptor.cs
+++ b/src/Autofac.Extras.AggregateService/ResolvingInterceptor.cs
@@ -10,165 +10,160 @@ using System.Reflection;
 using Autofac.Core;
 using Castle.DynamicProxy;
 
-namespace Autofac.Extras.AggregateService
+namespace Autofac.Extras.AggregateService;
+
+/// <summary>
+/// Interceptor that resolves types of properties and methods using a <see cref="IComponentContext"/>.
+/// </summary>
+public class ResolvingInterceptor : IInterceptor
 {
+    private static readonly Assembly _systemAssembly = typeof(Func<>).Assembly;
+
+    private readonly IComponentContext _context;
+
+    private readonly Dictionary<MethodInfo, Action<IInvocation>> _invocationMap;
+
     /// <summary>
-    /// Interceptor that resolves types of properties and methods using a <see cref="IComponentContext"/>.
+    /// Initializes a new instance of the <see cref="ResolvingInterceptor"/> class.
     /// </summary>
-    public class ResolvingInterceptor : IInterceptor
+    /// <param name="interfaceType">Type of the interface to intercept.</param>
+    /// <param name="context">The resolution context.</param>
+    public ResolvingInterceptor(Type interfaceType, IComponentContext context)
     {
-        private static readonly Assembly SystemAssembly = typeof(Func<>).Assembly;
+        _context = context;
+        _invocationMap = SetupInvocationMap(interfaceType);
+    }
 
-        private readonly IComponentContext _context;
-
-        private readonly Dictionary<MethodInfo, Action<IInvocation>> _invocationMap;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ResolvingInterceptor"/> class.
-        /// </summary>
-        /// <param name="interfaceType">Type of the interface to intercept.</param>
-        /// <param name="context">The resolution context.</param>
-        public ResolvingInterceptor(Type interfaceType, IComponentContext context)
+    /// <summary>
+    /// Intercepts a method invocation.
+    /// </summary>
+    /// <param name="invocation">
+    /// The method invocation to intercept.
+    /// </param>
+    public void Intercept(IInvocation invocation)
+    {
+        if (invocation == null)
         {
-            _context = context;
-            _invocationMap = SetupInvocationMap(interfaceType);
+            throw new ArgumentNullException(nameof(invocation));
         }
 
-        /// <summary>
-        /// Intercepts a method invocation.
-        /// </summary>
-        /// <param name="invocation">
-        /// The method invocation to intercept.
-        /// </param>
-        public void Intercept(IInvocation invocation)
+        // Generic methods need to use the open generic method definition.
+        var method = invocation.Method.IsGenericMethod ? invocation.Method.GetGenericMethodDefinition() : invocation.Method;
+        var invocationHandler = _invocationMap[method];
+        invocationHandler(invocation);
+    }
+
+    private static PropertyInfo? GetProperty(MethodInfo method)
+    {
+        var takesArg = method.GetParameters().Length == 1;
+        var hasReturn = method.ReturnType != typeof(void);
+
+        if (takesArg == hasReturn)
         {
-            if (invocation == null)
+            return null;
+        }
+
+        return method
+            .DeclaringType
+            .GetProperties()
+            .Where(prop => prop.GetGetMethod() == method)
+            .FirstOrDefault();
+    }
+
+    private static void InvalidReturnTypeInvocation(IInvocation invocation)
+    {
+        throw new InvalidOperationException(string.Format(CultureInfo.InvariantCulture, "The method {0} has invalid return type System.Void", invocation.Method));
+    }
+
+    [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode", Justification = "This method gets called via reflection.")]
+    [SuppressMessage("Microsoft.Performance", "IDE0051", Justification = "This method gets called via reflection.")]
+    private void MethodWithoutParams(IInvocation invocation)
+    {
+        // To handle open generics, this resolves the return type of the invocation rather than the scanned method.
+        invocation.ReturnValue = _context.Resolve(invocation.Method.ReturnType);
+    }
+
+    private Dictionary<MethodInfo, Action<IInvocation>> SetupInvocationMap(Type interfaceType)
+    {
+        var methods = interfaceType
+            .GetUniqueInterfaces()
+            .SelectMany(x => x.GetMethods())
+            .ToArray();
+
+        var methodMap = new Dictionary<MethodInfo, Action<IInvocation>>(methods.Length);
+        foreach (var method in methods)
+        {
+            var returnType = method.ReturnType;
+
+            if (returnType == typeof(void))
             {
-                throw new ArgumentNullException(nameof(invocation));
+                // Any method with 'void' return type (includes property setters) should throw an exception
+                methodMap.Add(method, InvalidReturnTypeInvocation);
+                continue;
             }
 
-            // Generic methods need to use the open generic method definition.
-            var method = invocation.Method.IsGenericMethod ? invocation.Method.GetGenericMethodDefinition() : invocation.Method;
-            var invocationHandler = _invocationMap[method];
-            invocationHandler(invocation);
-        }
-
-        private static PropertyInfo? GetProperty(MethodInfo method)
-        {
-            var takesArg = method.GetParameters().Length == 1;
-            var hasReturn = method.ReturnType != typeof(void);
-
-            if (takesArg == hasReturn)
+            if (GetProperty(method) != null)
             {
-                return null;
+                // All properties should be resolved at proxy instantiation
+                var propertyValue = _context.Resolve(returnType);
+                methodMap.Add(method, invocation => invocation.ReturnValue = propertyValue);
+                continue;
             }
 
-            return method
-                .DeclaringType
-                .GetProperties()
-                .Where(prop => prop.GetGetMethod() == method)
-                .FirstOrDefault();
-        }
-
-        private static void InvalidReturnTypeInvocation(IInvocation invocation)
-        {
-            throw new InvalidOperationException(string.Format(CultureInfo.InvariantCulture, "The method {0} has invalid return type System.Void", invocation.Method));
-        }
-
-        [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode", Justification = "This method gets called via reflection.")]
-        [SuppressMessage("Microsoft.Performance", "IDE0051", Justification = "This method gets called via reflection.")]
-        private void MethodWithoutParams(IInvocation invocation)
-        {
-            // To handle open generics, this resolves the return type of the invocation rather than the scanned method.
-            invocation.ReturnValue = _context.Resolve(invocation.Method.ReturnType);
-        }
-
-        private Dictionary<MethodInfo, Action<IInvocation>> SetupInvocationMap(Type interfaceType)
-        {
-            var methods = interfaceType
-                .GetUniqueInterfaces()
-                .SelectMany(x => x.GetMethods())
+            // For methods with parameters, cache parameter info for use at invocation time
+            var parameters = method.GetParameters()
+                .OrderBy(parameterInfo => parameterInfo.Position)
+                .Select(parameterInfo => new { parameterInfo.Position, parameterInfo.ParameterType })
                 .ToArray();
 
-            var methodMap = new Dictionary<MethodInfo, Action<IInvocation>>(methods.Length);
-            foreach (var method in methods)
+            if (parameters.Length > 0)
             {
-                var returnType = method.ReturnType;
-
-                if (returnType == typeof(void))
+                // Methods with parameters
+                if (parameters.Any(p => p.ParameterType.IsGenericType))
                 {
-                    // Any method with 'void' return type (includes property setters) should throw an exception
-                    methodMap.Add(method, InvalidReturnTypeInvocation);
-                    continue;
+                    // There are some open generic parameters so resolve a
+                    // Func<X, Y> corresponding to the method parameters and
+                    // method return type. Core Autofac will handle the type
+                    // mapping from open generic to closed generic, etc.
+                    methodMap.Add(
+                        method,
+                        invocation =>
+                        {
+                            var targetMethod = invocation.Method;
+                            var funcArgTypes = targetMethod.GetParameters().OrderBy(p => p.Position).Select(p => p.ParameterType).Append(targetMethod.ReturnType).ToArray();
+                            var funcTypeName = $"System.Func`{funcArgTypes.Length}";
+                            var baseFuncType = _systemAssembly.GetType(funcTypeName) ?? throw new NotSupportedException($"Unable to locate function type for dynamic resolution: {funcTypeName}. Ensure your method doesn't have too many parameters to convert to a System.Func delegate.");
+
+                            var builtFuncType = baseFuncType.MakeGenericType(funcArgTypes);
+                            var factory = (Delegate)_context.Resolve(builtFuncType);
+                            invocation.ReturnValue = factory!.DynamicInvoke(invocation.Arguments);
+                        });
+                }
+                else
+                {
+                    // There are no open generic parameters so we can simplify the backing method.
+                    methodMap.Add(
+                        method,
+                        invocation =>
+                        {
+                            var arguments = invocation.Arguments;
+                            var typedParameters = parameters
+                                .Select(info => (Parameter)new TypedParameter(info.ParameterType, arguments[info.Position]));
+
+                            // To handle open generics, this resolves the return type of the invocation rather than the scanned method.
+                            invocation.ReturnValue = _context.Resolve(invocation.Method.ReturnType, typedParameters);
+                        });
                 }
 
-                if (GetProperty(method) != null)
-                {
-                    // All properties should be resolved at proxy instantiation
-                    var propertyValue = _context.Resolve(returnType);
-                    methodMap.Add(method, invocation => invocation.ReturnValue = propertyValue);
-                    continue;
-                }
-
-                // For methods with parameters, cache parameter info for use at invocation time
-                var parameters = method.GetParameters()
-                    .OrderBy(parameterInfo => parameterInfo.Position)
-                    .Select(parameterInfo => new { parameterInfo.Position, parameterInfo.ParameterType })
-                    .ToArray();
-
-                if (parameters.Length > 0)
-                {
-                    // Methods with parameters
-                    if (parameters.Any(p => p.ParameterType.IsGenericType))
-                    {
-                        // There are some open generic parameters so resolve a
-                        // Func<X, Y> corresponding to the method parameters and
-                        // method return type. Core Autofac will handle the type
-                        // mapping from open generic to closed generic, etc.
-                        methodMap.Add(
-                            method,
-                            invocation =>
-                            {
-                                var targetMethod = invocation.Method;
-                                var funcArgTypes = targetMethod.GetParameters().OrderBy(p => p.Position).Select(p => p.ParameterType).Append(targetMethod.ReturnType).ToArray();
-                                var funcTypeName = $"System.Func`{funcArgTypes.Length}";
-                                var baseFuncType = SystemAssembly.GetType(funcTypeName);
-                                if (baseFuncType == null)
-                                {
-                                    throw new NotSupportedException($"Unable to locate function type for dynamic resolution: {funcTypeName}. Ensure your method doesn't have too many parameters to convert to a System.Func delegate.");
-                                }
-
-                                var builtFuncType = baseFuncType.MakeGenericType(funcArgTypes);
-                                var factory = (Delegate)_context.Resolve(builtFuncType);
-                                invocation.ReturnValue = factory!.DynamicInvoke(invocation.Arguments);
-                            });
-                    }
-                    else
-                    {
-                        // There are no open generic parameters so we can simplify the backing method.
-                        methodMap.Add(
-                            method,
-                            invocation =>
-                            {
-                                var arguments = invocation.Arguments;
-                                var typedParameters = parameters
-                                    .Select(info => (Parameter)new TypedParameter(info.ParameterType, arguments[info.Position]));
-
-                                // To handle open generics, this resolves the return type of the invocation rather than the scanned method.
-                                invocation.ReturnValue = _context.Resolve(invocation.Method.ReturnType, typedParameters);
-                            });
-                    }
-
-                    continue;
-                }
-
-                // Methods without parameters
-                var methodWithoutParams = GetType().GetMethod("MethodWithoutParams", BindingFlags.Instance | BindingFlags.NonPublic);
-                var methodWithoutParamsDelegate = (Action<IInvocation>)methodWithoutParams.CreateDelegate(typeof(Action<IInvocation>), this);
-                methodMap.Add(method, methodWithoutParamsDelegate);
+                continue;
             }
 
-            return methodMap;
+            // Methods without parameters
+            var methodWithoutParams = GetType().GetMethod("MethodWithoutParams", BindingFlags.Instance | BindingFlags.NonPublic);
+            var methodWithoutParamsDelegate = (Action<IInvocation>)methodWithoutParams.CreateDelegate(typeof(Action<IInvocation>), this);
+            methodMap.Add(method, methodWithoutParamsDelegate);
         }
+
+        return methodMap;
     }
 }

--- a/src/Autofac.Extras.AggregateService/TypeExtensions.cs
+++ b/src/Autofac.Extras.AggregateService/TypeExtensions.cs
@@ -5,42 +5,41 @@ using System;
 using System.Collections.Generic;
 using System.Reflection;
 
-namespace Autofac.Extras.AggregateService
+namespace Autofac.Extras.AggregateService;
+
+/// <summary>
+/// Extension methods for working with <see cref="System.Type"/>.
+/// </summary>
+internal static class TypeExtensions
 {
     /// <summary>
-    /// Extension methods for working with <see cref="System.Type"/>.
+    /// Return unique interfaces implemented or inherited by <paramref name="type"/>.
+    /// Will also include <paramref name="type"/> if it is an interface type.
     /// </summary>
-    internal static class TypeExtensions
+    /// <param name="type">
+    /// The type for which interfaces should be retrieved.
+    /// </param>
+    /// <returns>
+    /// A list of unique interfaces implemented by the provided type.
+    /// </returns>
+    public static IEnumerable<Type> GetUniqueInterfaces(this Type type)
     {
-        /// <summary>
-        /// Return unique interfaces implemented or inherited by <paramref name="type"/>.
-        /// Will also include <paramref name="type"/> if it is an interface type.
-        /// </summary>
-        /// <param name="type">
-        /// The type for which interfaces should be retrieved.
-        /// </param>
-        /// <returns>
-        /// A list of unique interfaces implemented by the provided type.
-        /// </returns>
-        public static IEnumerable<Type> GetUniqueInterfaces(this Type type)
+        var types = new HashSet<Type>();
+        foreach (var interfaceType in type.GetInterfaces())
         {
-            var types = new HashSet<Type>();
-            foreach (var interfaceType in type.GetInterfaces())
+            if (types.Contains(interfaceType))
             {
-                if (types.Contains(interfaceType))
-                {
-                    continue;
-                }
-
-                types.Add(interfaceType);
+                continue;
             }
 
-            if (type.GetTypeInfo().IsInterface && !types.Contains(type))
-            {
-                types.Add(type);
-            }
-
-            return types;
+            types.Add(interfaceType);
         }
+
+        if (type.GetTypeInfo().IsInterface && !types.Contains(type))
+        {
+            types.Add(type);
+        }
+
+        return types;
     }
 }

--- a/test/Autofac.Extras.AggregateService.Test/AggregateServiceFixture.cs
+++ b/test/Autofac.Extras.AggregateService.Test/AggregateServiceFixture.cs
@@ -5,101 +5,100 @@ using System;
 using NSubstitute;
 using Xunit;
 
-namespace Autofac.Extras.AggregateService.Test
+namespace Autofac.Extras.AggregateService.Test;
+
+public class AggregateServiceFixture
 {
-    public class AggregateServiceFixture
+    private readonly IContainer _container;
+
+    private readonly ISomeDependency _someDependencyMock;
+
+    private readonly IMyContext _aggregateService;
+
+    public AggregateServiceFixture()
     {
-        private readonly IContainer _container;
+        _someDependencyMock = Substitute.For<ISomeDependency>();
 
-        private readonly ISomeDependency _someDependencyMock;
+        var builder = new ContainerBuilder();
+        builder.RegisterAggregateService<IMyContext>();
+        builder.RegisterType<MyServiceImpl>()
+            .As<IMyService>()
+            .InstancePerDependency();
+        builder.RegisterInstance(_someDependencyMock);
+        _container = builder.Build();
 
-        private readonly IMyContext _aggregateService;
+        _aggregateService = _container.Resolve<IMyContext>();
+    }
 
-        public AggregateServiceFixture()
-        {
-            _someDependencyMock = Substitute.For<ISomeDependency>();
+    [Fact]
+    public void Property_ResolvesService()
+    {
+        var service = _aggregateService.MyService;
+        Assert.NotNull(service);
+        Assert.IsAssignableFrom<IMyService>(service);
+    }
 
-            var builder = new ContainerBuilder();
-            builder.RegisterAggregateService<IMyContext>();
-            builder.RegisterType<MyServiceImpl>()
-                .As<IMyService>()
-                .InstancePerDependency();
-            builder.RegisterInstance(_someDependencyMock);
-            _container = builder.Build();
+    [Fact]
+    public void Property_Getter_AlwaysReturnSameInstance()
+    {
+        var firstInstance = _aggregateService.MyService;
+        var secondInstance = _aggregateService.MyService;
 
-            _aggregateService = _container.Resolve<IMyContext>();
-        }
+        Assert.Same(secondInstance, firstInstance);
+    }
 
-        [Fact]
-        public void Property_ResolvesService()
-        {
-            var service = _aggregateService.MyService;
-            Assert.NotNull(service);
-            Assert.IsAssignableFrom<IMyService>(service);
-        }
+    [Fact]
+    public void Property_Setter_Throws()
+    {
+        Assert.Throws<InvalidOperationException>(() => _aggregateService.PropertyWithSetter = null);
+    }
 
-        [Fact]
-        public void Property_Getter_AlwaysReturnSameInstance()
-        {
-            var firstInstance = _aggregateService.MyService;
-            var secondInstance = _aggregateService.MyService;
+    [Fact]
+    public void Method_WithVoid_Throws()
+    {
+        Assert.Throws<InvalidOperationException>(() => _aggregateService.MethodWithoutReturnValue());
+    }
 
-            Assert.Same(secondInstance, firstInstance);
-        }
+    [Fact]
+    public void Method_ResolvesService()
+    {
+        var service = _aggregateService.GetMyService();
+        Assert.NotNull(service);
+        Assert.IsAssignableFrom<IMyService>(service);
+    }
 
-        [Fact]
-        public void Property_Setter_Throws()
-        {
-            Assert.Throws<InvalidOperationException>(() => _aggregateService.PropertyWithSetter = null);
-        }
+    [Fact]
+    public void Method_WithParameter_PassesParameterToService()
+    {
+        var myService = _aggregateService.GetMyService(10);
 
-        [Fact]
-        public void Method_WithVoid_Throws()
-        {
-            Assert.Throws<InvalidOperationException>(() => _aggregateService.MethodWithoutReturnValue());
-        }
+        Assert.Equal(10, myService.SomeIntValue);
+    }
 
-        [Fact]
-        public void Method_ResolvesService()
-        {
-            var service = _aggregateService.GetMyService();
-            Assert.NotNull(service);
-            Assert.IsAssignableFrom<IMyService>(service);
-        }
+    [Fact]
+    public void Method_WithParameters_PassesParametersToService()
+    {
+        var someDate = DateTime.Now;
+        var myService = _aggregateService.GetMyService(someDate, 20);
 
-        [Fact]
-        public void Method_WithParameter_PassesParameterToService()
-        {
-            var myService = _aggregateService.GetMyService(10);
+        Assert.Equal(someDate, myService.SomeDateValue);
+        Assert.Equal(20, myService.SomeIntValue);
+    }
 
-            Assert.Equal(10, myService.SomeIntValue);
-        }
+    [Fact]
+    public void Method_WithNullParameters_PassesParametersToService()
+    {
+        var myService = _aggregateService.GetMyService(null);
 
-        [Fact]
-        public void Method_WithParameters_PassesParametersToService()
-        {
-            var someDate = DateTime.Now;
-            var myService = _aggregateService.GetMyService(someDate, 20);
+        Assert.Null(myService.SomeStringValue);
+    }
 
-            Assert.Equal(someDate, myService.SomeDateValue);
-            Assert.Equal(20, myService.SomeIntValue);
-        }
+    [Fact]
+    public void Method_WithParameter_PassesParameterAndOtherDependenciesToService()
+    {
+        var myService = _aggregateService.GetMyService("text");
 
-        [Fact]
-        public void Method_WithNullParameters_PassesParametersToService()
-        {
-            var myService = _aggregateService.GetMyService(null);
-
-            Assert.Null(myService.SomeStringValue);
-        }
-
-        [Fact]
-        public void Method_WithParameter_PassesParameterAndOtherDependenciesToService()
-        {
-            var myService = _aggregateService.GetMyService("text");
-
-            Assert.Equal("text", myService.SomeStringValue);
-            Assert.Equal(_someDependencyMock, myService.SomeDependency);
-        }
+        Assert.Equal("text", myService.SomeStringValue);
+        Assert.Equal(_someDependencyMock, myService.SomeDependency);
     }
 }

--- a/test/Autofac.Extras.AggregateService.Test/AggregateServiceGeneratorFixture.cs
+++ b/test/Autofac.Extras.AggregateService.Test/AggregateServiceGeneratorFixture.cs
@@ -5,51 +5,50 @@ using System;
 using NSubstitute;
 using Xunit;
 
-namespace Autofac.Extras.AggregateService.Test
+namespace Autofac.Extras.AggregateService.Test;
+
+public class AggregateServiceGeneratorFixture
 {
-    public class AggregateServiceGeneratorFixture
+    private readonly IContainer _container;
+
+    public AggregateServiceGeneratorFixture()
     {
-        private readonly IContainer _container;
+        var builder = new ContainerBuilder();
+        builder.RegisterInstance(Substitute.For<IMyService>());
+        _container = builder.Build();
+    }
 
-        public AggregateServiceGeneratorFixture()
-        {
-            var builder = new ContainerBuilder();
-            builder.RegisterInstance(Substitute.For<IMyService>());
-            _container = builder.Build();
-        }
+    [Fact]
+    public void CreateInstance_WithGenericInterface_CreatesInstanceOfInterface()
+    {
+        var instance = AggregateServiceGenerator.CreateInstance<IMyContext>(_container);
 
-        [Fact]
-        public void CreateInstance_WithGenericInterface_CreatesInstanceOfInterface()
-        {
-            var instance = AggregateServiceGenerator.CreateInstance<IMyContext>(_container);
+        Assert.IsAssignableFrom<IMyContext>(instance);
+    }
 
-            Assert.IsAssignableFrom<IMyContext>(instance);
-        }
+    [Fact]
+    public void CreateInstance_WithInterfaceType_CreatesInstanceOfInterface()
+    {
+        var instance = AggregateServiceGenerator.CreateInstance(typeof(IMyContext), _container);
 
-        [Fact]
-        public void CreateInstance_WithInterfaceType_CreatesInstanceOfInterface()
-        {
-            var instance = AggregateServiceGenerator.CreateInstance(typeof(IMyContext), _container);
+        Assert.IsAssignableFrom<IMyContext>(instance);
+    }
 
-            Assert.IsAssignableFrom<IMyContext>(instance);
-        }
+    [Fact]
+    public void CreateInstance_ExpectsInterfaceTypeInstance()
+    {
+        Assert.Throws<ArgumentNullException>(() => AggregateServiceGenerator.CreateInstance(null, _container));
+    }
 
-        [Fact]
-        public void CreateInstance_ExpectsInterfaceTypeInstance()
-        {
-            Assert.Throws<ArgumentNullException>(() => AggregateServiceGenerator.CreateInstance(null, _container));
-        }
+    [Fact]
+    public void CreateInstance_ExpectsComponentInstance()
+    {
+        Assert.Throws<ArgumentNullException>(() => AggregateServiceGenerator.CreateInstance(typeof(IMyContext), null));
+    }
 
-        [Fact]
-        public void CreateInstance_ExpectsComponentInstance()
-        {
-            Assert.Throws<ArgumentNullException>(() => AggregateServiceGenerator.CreateInstance(typeof(IMyContext), null));
-        }
-
-        [Fact]
-        public void CreateInstance_ExpectsInterfaceType()
-        {
-            Assert.Throws<ArgumentException>(() => AggregateServiceGenerator.CreateInstance<string>(_container));
-        }
+    [Fact]
+    public void CreateInstance_ExpectsInterfaceType()
+    {
+        Assert.Throws<ArgumentException>(() => AggregateServiceGenerator.CreateInstance<string>(_container));
     }
 }

--- a/test/Autofac.Extras.AggregateService.Test/AggregateServiceGenericsFixture.cs
+++ b/test/Autofac.Extras.AggregateService.Test/AggregateServiceGenericsFixture.cs
@@ -4,63 +4,62 @@
 using System;
 using Xunit;
 
-namespace Autofac.Extras.AggregateService.Test
+namespace Autofac.Extras.AggregateService.Test;
+
+public class AggregateServiceGenericsFixture
 {
-    public class AggregateServiceGenericsFixture
+    private readonly IContainer _container;
+
+    public AggregateServiceGenericsFixture()
     {
-        private readonly IContainer _container;
+        var builder = new ContainerBuilder();
+        builder.RegisterAggregateService<IOpenGenericAggregate>();
+        builder.RegisterGeneric(typeof(OpenGenericImpl<>))
+            .As(typeof(IOpenGeneric<>));
+        builder.RegisterGeneric(typeof(PassThroughOpenGenericImpl<>))
+            .As(typeof(IPassThroughOpenGeneric<>));
 
-        public AggregateServiceGenericsFixture()
-        {
-            var builder = new ContainerBuilder();
-            builder.RegisterAggregateService<IOpenGenericAggregate>();
-            builder.RegisterGeneric(typeof(OpenGenericImpl<>))
-                .As(typeof(IOpenGeneric<>));
-            builder.RegisterGeneric(typeof(PassThroughOpenGenericImpl<>))
-                .As(typeof(IPassThroughOpenGeneric<>));
+        _container = builder.Build();
+    }
 
-            _container = builder.Build();
-        }
+    /// <summary>
+    /// Attempts to resolve an open generic by a method call.
+    /// </summary>
+    [Fact]
+    public void Method_ResolveOpenGeneric()
+    {
+        var aggregateService = _container.Resolve<IOpenGenericAggregate>();
 
-        /// <summary>
-        /// Attempts to resolve an open generic by a method call.
-        /// </summary>
-        [Fact]
-        public void Method_ResolveOpenGeneric()
-        {
-            var aggregateService = _container.Resolve<IOpenGenericAggregate>();
+        var generic = aggregateService.GetOpenGeneric<object>();
+        Assert.NotNull(generic);
 
-            var generic = aggregateService.GetOpenGeneric<object>();
-            Assert.NotNull(generic);
+        var notGeneric = aggregateService.GetResolvedGeneric();
+        Assert.NotNull(notGeneric);
+        Assert.NotSame(generic, notGeneric);
+    }
 
-            var notGeneric = aggregateService.GetResolvedGeneric();
-            Assert.NotNull(notGeneric);
-            Assert.NotSame(generic, notGeneric);
-        }
+    [Fact]
+    public void Method_TooManyParameters()
+    {
+        // Issue #11: A function that takes a generic parameter doesn't use the parameter value.
+        var aggregateService = _container.Resolve<IOpenGenericAggregate>();
 
-        [Fact]
-        public void Method_TooManyParameters()
-        {
-            // Issue #11: A function that takes a generic parameter doesn't use the parameter value.
-            var aggregateService = _container.Resolve<IOpenGenericAggregate>();
+        var param = aggregateService.GetOpenGeneric<object>();
+        Assert.NotNull(param);
 
-            var param = aggregateService.GetOpenGeneric<object>();
-            Assert.NotNull(param);
+        Assert.Throws<NotSupportedException>(() => aggregateService.TooManyParameters(param, "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r"));
+    }
 
-            Assert.Throws<NotSupportedException>(() => aggregateService.TooManyParameters(param, "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r"));
-        }
+    [Fact]
+    public void Method_WithOpenGenericParameter()
+    {
+        // Issue #11: A function that takes a generic parameter doesn't use the parameter value.
+        var aggregateService = _container.Resolve<IOpenGenericAggregate>();
 
-        [Fact]
-        public void Method_WithOpenGenericParameter()
-        {
-            // Issue #11: A function that takes a generic parameter doesn't use the parameter value.
-            var aggregateService = _container.Resolve<IOpenGenericAggregate>();
+        var param = aggregateService.GetOpenGeneric<object>();
+        Assert.NotNull(param);
 
-            var param = aggregateService.GetOpenGeneric<object>();
-            Assert.NotNull(param);
-
-            var passThrough = aggregateService.UseOpenGenericParameter(param);
-            Assert.Same(param, passThrough.OpenGeneric);
-        }
+        var passThrough = aggregateService.UseOpenGenericParameter(param);
+        Assert.Same(param, passThrough.OpenGeneric);
     }
 }

--- a/test/Autofac.Extras.AggregateService.Test/AggregateServiceInheritanceFixture.cs
+++ b/test/Autofac.Extras.AggregateService.Test/AggregateServiceInheritanceFixture.cs
@@ -4,42 +4,41 @@
 using NSubstitute;
 using Xunit;
 
-namespace Autofac.Extras.AggregateService.Test
+namespace Autofac.Extras.AggregateService.Test;
+
+public class AggregateServiceInheritanceFixture
 {
-    public class AggregateServiceInheritanceFixture
+    private readonly IContainer _container;
+
+    private readonly ISubService _aggregateService;
+
+    private readonly ISomeDependency _someDependencyMock;
+
+    private readonly ISomeOtherDependency _someOtherDependencyMock;
+
+    public AggregateServiceInheritanceFixture()
     {
-        private readonly IContainer _container;
+        _someDependencyMock = Substitute.For<ISomeDependency>();
+        _someOtherDependencyMock = Substitute.For<ISomeOtherDependency>();
 
-        private readonly ISubService _aggregateService;
+        var builder = new ContainerBuilder();
+        builder.RegisterAggregateService<ISubService>();
+        builder.RegisterInstance(_someDependencyMock);
+        builder.RegisterInstance(_someOtherDependencyMock);
+        _container = builder.Build();
 
-        private readonly ISomeDependency _someDependencyMock;
+        _aggregateService = _container.Resolve<ISubService>();
+    }
 
-        private readonly ISomeOtherDependency _someOtherDependencyMock;
+    [Fact]
+    public void Resolve_PropertyOnSuperType()
+    {
+        Assert.Equal(_someDependencyMock, _aggregateService.SomeDependency);
+    }
 
-        public AggregateServiceInheritanceFixture()
-        {
-            _someDependencyMock = Substitute.For<ISomeDependency>();
-            _someOtherDependencyMock = Substitute.For<ISomeOtherDependency>();
-
-            var builder = new ContainerBuilder();
-            builder.RegisterAggregateService<ISubService>();
-            builder.RegisterInstance(_someDependencyMock);
-            builder.RegisterInstance(_someOtherDependencyMock);
-            _container = builder.Build();
-
-            _aggregateService = _container.Resolve<ISubService>();
-        }
-
-        [Fact]
-        public void Resolve_PropertyOnSuperType()
-        {
-            Assert.Equal(_someDependencyMock, _aggregateService.SomeDependency);
-        }
-
-        [Fact]
-        public void Resolve_PropertyOnSubType()
-        {
-            Assert.Equal(_someOtherDependencyMock, _aggregateService.SomeOtherDependency);
-        }
+    [Fact]
+    public void Resolve_PropertyOnSubType()
+    {
+        Assert.Equal(_someOtherDependencyMock, _aggregateService.SomeOtherDependency);
     }
 }

--- a/test/Autofac.Extras.AggregateService.Test/AggregateServiceOpenGenericFixture.cs
+++ b/test/Autofac.Extras.AggregateService.Test/AggregateServiceOpenGenericFixture.cs
@@ -5,108 +5,107 @@ using System;
 using System.Linq;
 using Xunit;
 
-namespace Autofac.Extras.AggregateService.Test
+namespace Autofac.Extras.AggregateService.Test;
+
+public class AggregateServiceOpenGenericFixture
 {
-    public class AggregateServiceOpenGenericFixture
+    private readonly IContainer _container;
+    private readonly IContainer _containerClosedRegistrations;
+
+    public AggregateServiceOpenGenericFixture()
     {
-        private readonly IContainer _container;
-        private readonly IContainer _containerClosedRegistrations;
+        var builder = new ContainerBuilder();
+        builder.RegisterAggregateService(typeof(IOpenGenericAggregateWithTypeParameter<>));
+        builder.RegisterGeneric(typeof(OpenGenericImpl<>))
+            .As(typeof(IOpenGeneric<>));
 
-        public AggregateServiceOpenGenericFixture()
-        {
-            var builder = new ContainerBuilder();
-            builder.RegisterAggregateService(typeof(IOpenGenericAggregateWithTypeParameter<>));
-            builder.RegisterGeneric(typeof(OpenGenericImpl<>))
-                .As(typeof(IOpenGeneric<>));
+        builder.RegisterInstance("Hello World!");
+        builder.RegisterType<MyServiceImpl>().As<IMyService>();
 
-            builder.RegisterInstance("Hello World!");
-            builder.RegisterType<MyServiceImpl>().As<IMyService>();
+        _container = builder.Build();
 
-            _container = builder.Build();
+        // Closed registration to test for regression issues.
+        var builderClosed = new ContainerBuilder();
+        builderClosed.RegisterAggregateService(typeof(IOpenGenericAggregateWithTypeParameter<string>));
+        builderClosed.RegisterAggregateService(typeof(IOpenGenericAggregateWithTypeParameter<IMyService>));
+        builderClosed.RegisterGeneric(typeof(OpenGenericImpl<>))
+            .As(typeof(IOpenGeneric<>));
 
-            // Closed registration to test for regression issues.
-            var builderClosed = new ContainerBuilder();
-            builderClosed.RegisterAggregateService(typeof(IOpenGenericAggregateWithTypeParameter<string>));
-            builderClosed.RegisterAggregateService(typeof(IOpenGenericAggregateWithTypeParameter<IMyService>));
-            builderClosed.RegisterGeneric(typeof(OpenGenericImpl<>))
-                .As(typeof(IOpenGeneric<>));
+        builderClosed.RegisterType<MyServiceImpl>().As<IMyService>();
+        builderClosed.RegisterInstance("Hello World!");
 
-            builderClosed.RegisterType<MyServiceImpl>().As<IMyService>();
-            builderClosed.RegisterInstance("Hello World!");
+        _containerClosedRegistrations = builderClosed.Build();
+    }
 
-            _containerClosedRegistrations = builderClosed.Build();
-        }
+    [Fact]
+    public void ResolvePropertyAsString()
+    {
+        var aggregateService = _container.Resolve<IOpenGenericAggregateWithTypeParameter<string>>();
 
-        [Fact]
-        public void ResolvePropertyAsString()
-        {
-            var aggregateService = _container.Resolve<IOpenGenericAggregateWithTypeParameter<string>>();
+        var typeOfSomeProperty = aggregateService.SomeProperty.GetType();
+        Assert.Same(typeof(string), typeOfSomeProperty);
+        Assert.Same("Hello World!", aggregateService.SomeProperty);
 
-            var typeOfSomeProperty = aggregateService.SomeProperty.GetType();
-            Assert.Same(typeof(string), typeOfSomeProperty);
-            Assert.Same("Hello World!", aggregateService.SomeProperty);
+        var generic = aggregateService.OpenGeneric;
+        Assert.NotNull(generic);
+        var typeOfOpenGeneric = generic.GetType().GetGenericArguments().Single();
+        Assert.Same(typeof(string), typeOfOpenGeneric);
+    }
 
-            var generic = aggregateService.OpenGeneric;
-            Assert.NotNull(generic);
-            var typeOfOpenGeneric = generic.GetType().GetGenericArguments().Single();
-            Assert.Same(typeof(string), typeOfOpenGeneric);
-        }
+    [Fact]
+    public void ResolvePropertyAsMyService()
+    {
+        var aggregateService = _container.Resolve<IOpenGenericAggregateWithTypeParameter<IMyService>>();
 
-        [Fact]
-        public void ResolvePropertyAsMyService()
-        {
-            var aggregateService = _container.Resolve<IOpenGenericAggregateWithTypeParameter<IMyService>>();
+        var typeOfSomeProperty = aggregateService.SomeProperty.GetType();
+        Assert.Same(typeof(MyServiceImpl), typeOfSomeProperty);
 
-            var typeOfSomeProperty = aggregateService.SomeProperty.GetType();
-            Assert.Same(typeof(MyServiceImpl), typeOfSomeProperty);
+        var generic = aggregateService.OpenGeneric;
+        Assert.NotNull(generic);
+        var typeOfOpenGeneric = generic.GetType().GetGenericArguments().Single();
+        Assert.Same(typeof(IMyService), typeOfOpenGeneric);
+    }
 
-            var generic = aggregateService.OpenGeneric;
-            Assert.NotNull(generic);
-            var typeOfOpenGeneric = generic.GetType().GetGenericArguments().Single();
-            Assert.Same(typeof(IMyService), typeOfOpenGeneric);
-        }
+    [Fact]
+    public void ResolvePropertyAsStringClosed()
+    {
+        var aggregateService = _containerClosedRegistrations.Resolve<IOpenGenericAggregateWithTypeParameter<string>>();
 
-        [Fact]
-        public void ResolvePropertyAsStringClosed()
-        {
-            var aggregateService = _containerClosedRegistrations.Resolve<IOpenGenericAggregateWithTypeParameter<string>>();
+        var typeOfSomeProperty = aggregateService.SomeProperty.GetType();
+        Assert.Same(typeof(string), typeOfSomeProperty);
+        Assert.Same("Hello World!", aggregateService.SomeProperty);
 
-            var typeOfSomeProperty = aggregateService.SomeProperty.GetType();
-            Assert.Same(typeof(string), typeOfSomeProperty);
-            Assert.Same("Hello World!", aggregateService.SomeProperty);
+        var generic = aggregateService.OpenGeneric;
+        Assert.NotNull(generic);
+        var typeOfOpenGeneric = generic.GetType().GetGenericArguments().Single();
+        Assert.Same(typeof(string), typeOfOpenGeneric);
+    }
 
-            var generic = aggregateService.OpenGeneric;
-            Assert.NotNull(generic);
-            var typeOfOpenGeneric = generic.GetType().GetGenericArguments().Single();
-            Assert.Same(typeof(string), typeOfOpenGeneric);
-        }
+    [Fact]
+    public void ResolvePropertyAsMyServiceClosed()
+    {
+        var aggregateService = _containerClosedRegistrations.Resolve<IOpenGenericAggregateWithTypeParameter<IMyService>>();
 
-        [Fact]
-        public void ResolvePropertyAsMyServiceClosed()
-        {
-            var aggregateService = _containerClosedRegistrations.Resolve<IOpenGenericAggregateWithTypeParameter<IMyService>>();
+        var typeOfSomeProperty = aggregateService.SomeProperty.GetType();
+        Assert.Same(typeof(MyServiceImpl), typeOfSomeProperty);
 
-            var typeOfSomeProperty = aggregateService.SomeProperty.GetType();
-            Assert.Same(typeof(MyServiceImpl), typeOfSomeProperty);
+        var generic = aggregateService.OpenGeneric;
+        Assert.NotNull(generic);
+        var typeOfOpenGeneric = generic.GetType().GetGenericArguments().Single();
+        Assert.Same(typeof(IMyService), typeOfOpenGeneric);
+    }
 
-            var generic = aggregateService.OpenGeneric;
-            Assert.NotNull(generic);
-            var typeOfOpenGeneric = generic.GetType().GetGenericArguments().Single();
-            Assert.Same(typeof(IMyService), typeOfOpenGeneric);
-        }
+    [Fact]
+    public void DeeplyNestedOpenGenericIsNotSupported()
+    {
+        var builder = new ContainerBuilder();
 
-        [Fact]
-        public void DeeplyNestedOpenGenericIsNotSupported()
-        {
-            var builder = new ContainerBuilder();
+        // while
+        // builder.RegisterAggregateService(typeof(IOpenGenericAggregateWithTypeParameter<IOpenGeneric<>>));
+        // is not syntactical legal, the following however is.
+        var myTrickyType = typeof(IOpenGenericAggregateWithTypeParameter<>).MakeGenericType(typeof(IOpenGeneric<>));
 
-            // while
-            // builder.RegisterAggregateService(typeof(IOpenGenericAggregateWithTypeParameter<IOpenGeneric<>>));
-            // is not syntactical legal, the following however is.
-            var myTrickyType = typeof(IOpenGenericAggregateWithTypeParameter<>).MakeGenericType(typeof(IOpenGeneric<>));
-
-            var action = new Action(() => builder.RegisterAggregateService(myTrickyType));
-            Assert.Throws<ArgumentException>(action);
-        }
+        var action = new Action(() => builder.RegisterAggregateService(myTrickyType));
+        Assert.Throws<ArgumentException>(action);
     }
 }

--- a/test/Autofac.Extras.AggregateService.Test/ContainerBuilderExtensionsFixture.cs
+++ b/test/Autofac.Extras.AggregateService.Test/ContainerBuilderExtensionsFixture.cs
@@ -5,79 +5,78 @@ using System;
 using NSubstitute;
 using Xunit;
 
-namespace Autofac.Extras.AggregateService.Test
+namespace Autofac.Extras.AggregateService.Test;
+
+public class ContainerBuilderExtensionsFixture
 {
-    public class ContainerBuilderExtensionsFixture
+    [Fact]
+    public void RegisterAggregateService_WithGeneric_RegistersServiceInterface()
     {
-        [Fact]
-        public void RegisterAggregateService_WithGeneric_RegistersServiceInterface()
-        {
-            var builder = new ContainerBuilder();
-            builder.RegisterAggregateService<IMyContext>();
-            var container = builder.Build();
+        var builder = new ContainerBuilder();
+        builder.RegisterAggregateService<IMyContext>();
+        var container = builder.Build();
 
-            Assert.True(container.IsRegistered<IMyContext>());
-        }
+        Assert.True(container.IsRegistered<IMyContext>());
+    }
 
-        [Fact]
-        public void RegisterAggregateService_WithType_RegistersServiceInterface()
-        {
-            var builder = new ContainerBuilder();
-            builder.RegisterAggregateService(typeof(IMyContext));
-            var container = builder.Build();
+    [Fact]
+    public void RegisterAggregateService_WithType_RegistersServiceInterface()
+    {
+        var builder = new ContainerBuilder();
+        builder.RegisterAggregateService(typeof(IMyContext));
+        var container = builder.Build();
 
-            Assert.True(container.IsRegistered<IMyContext>());
-        }
+        Assert.True(container.IsRegistered<IMyContext>());
+    }
 
-        [Fact]
-        public void RegisterAggregateService_WithNullInterfaceType_ThrowsArgumentNullException()
-        {
-            var builder = new ContainerBuilder();
-            Assert.Throws<ArgumentNullException>(() => builder.RegisterAggregateService(null));
-        }
+    [Fact]
+    public void RegisterAggregateService_WithNullInterfaceType_ThrowsArgumentNullException()
+    {
+        var builder = new ContainerBuilder();
+        Assert.Throws<ArgumentNullException>(() => builder.RegisterAggregateService(null));
+    }
 
-        [Fact]
-        public void RegisterAggregateService_WithNonInterfaceType_ThrowsArgumentException()
-        {
-            var builder = new ContainerBuilder();
-            Assert.Throws<ArgumentException>(() => builder.RegisterAggregateService(typeof(MyServiceImpl)));
-        }
+    [Fact]
+    public void RegisterAggregateService_WithNonInterfaceType_ThrowsArgumentException()
+    {
+        var builder = new ContainerBuilder();
+        Assert.Throws<ArgumentException>(() => builder.RegisterAggregateService(typeof(MyServiceImpl)));
+    }
 
-        [Fact]
-        public void RegisterAggregateService_WithGenericNonInterfaceType_ThrowsArgumentException()
-        {
-            var builder = new ContainerBuilder();
-            Assert.Throws<ArgumentException>(() => builder.RegisterAggregateService<MyServiceImpl>());
-        }
+    [Fact]
+    public void RegisterAggregateService_WithGenericNonInterfaceType_ThrowsArgumentException()
+    {
+        var builder = new ContainerBuilder();
+        Assert.Throws<ArgumentException>(() => builder.RegisterAggregateService<MyServiceImpl>());
+    }
 
-        [Fact]
-        public void RegisterAggregateService_DifferentLifeTimeScopes_YieldsDifferentInstances()
-        {
-            var builder = new ContainerBuilder();
-            builder.RegisterAggregateService(typeof(IMyContext));
-            builder.RegisterType<MyServiceImpl>()
-                .As<IMyService>()
-                .InstancePerLifetimeScope();
-            var container = builder.Build();
+    [Fact]
+    public void RegisterAggregateService_DifferentLifeTimeScopes_YieldsDifferentInstances()
+    {
+        var builder = new ContainerBuilder();
+        builder.RegisterAggregateService(typeof(IMyContext));
+        builder.RegisterType<MyServiceImpl>()
+            .As<IMyService>()
+            .InstancePerLifetimeScope();
+        var container = builder.Build();
 
-            var rootScope = container.Resolve<IMyContext>();
-            var subScope = container.BeginLifetimeScope().Resolve<IMyContext>();
+        var rootScope = container.Resolve<IMyContext>();
+        var subScope = container.BeginLifetimeScope().Resolve<IMyContext>();
 
-            Assert.NotSame(subScope.MyService, rootScope.MyService);
-        }
+        Assert.NotSame(subScope.MyService, rootScope.MyService);
+    }
 
-        [Fact]
-        public void RegisterAggregateService_IsPerDependencyScoped()
-        {
-            var builder = new ContainerBuilder();
-            builder.RegisterAggregateService<IMyContext>();
-            builder.RegisterInstance(Substitute.For<IMyService>());
-            var container = builder.Build();
+    [Fact]
+    public void RegisterAggregateService_IsPerDependencyScoped()
+    {
+        var builder = new ContainerBuilder();
+        builder.RegisterAggregateService<IMyContext>();
+        builder.RegisterInstance(Substitute.For<IMyService>());
+        var container = builder.Build();
 
-            var firstInstance = container.Resolve<IMyContext>();
-            var secondInstance = container.Resolve<IMyContext>();
+        var firstInstance = container.Resolve<IMyContext>();
+        var secondInstance = container.Resolve<IMyContext>();
 
-            Assert.NotSame(secondInstance, firstInstance);
-        }
+        Assert.NotSame(secondInstance, firstInstance);
     }
 }

--- a/test/Autofac.Extras.AggregateService.Test/IMyContext.cs
+++ b/test/Autofac.Extras.AggregateService.Test/IMyContext.cs
@@ -3,33 +3,38 @@
 
 using System;
 
-namespace Autofac.Extras.AggregateService.Test
+namespace Autofac.Extras.AggregateService.Test;
+
+/// <summary>
+/// Interface illustrating an aggregate service context with supported and unsupported
+/// method signatures.
+/// </summary>
+public interface IMyContext
 {
-    /// <summary>
-    /// Interface illustrating an aggregate service context with supported and unsupported
-    /// method signatures.
-    /// </summary>
-    public interface IMyContext
+    // Supported
+    IMyService MyService
     {
-        // Supported
-        IMyService MyService { get; }
-
-        // Unsupported
-        IMyService PropertyWithSetter { get; set; }
-
-        // Supported
-        IMyService GetMyService();
-
-        // Supported
-        IMyService GetMyService(int someValue);
-
-        // Supported
-        IMyService GetMyService(string someOtherValue);
-
-        // Supported
-        IMyService GetMyService(DateTime someDate, int someInt);
-
-        // Unsupported
-        void MethodWithoutReturnValue();
+        get;
     }
+
+    // Unsupported
+    IMyService PropertyWithSetter
+    {
+        get; set;
+    }
+
+    // Supported
+    IMyService GetMyService();
+
+    // Supported
+    IMyService GetMyService(int someValue);
+
+    // Supported
+    IMyService GetMyService(string someOtherValue);
+
+    // Supported
+    IMyService GetMyService(DateTime someDate, int someInt);
+
+    // Unsupported
+    void MethodWithoutReturnValue();
 }

--- a/test/Autofac.Extras.AggregateService.Test/IMyService.cs
+++ b/test/Autofac.Extras.AggregateService.Test/IMyService.cs
@@ -3,19 +3,30 @@
 
 using System;
 
-namespace Autofac.Extras.AggregateService.Test
+namespace Autofac.Extras.AggregateService.Test;
+
+/// <summary>
+/// A sample service interface.
+/// </summary>
+public interface IMyService
 {
-    /// <summary>
-    /// A sample service interface.
-    /// </summary>
-    public interface IMyService
+    DateTime SomeDateValue
     {
-        DateTime SomeDateValue { get; }
+        get;
+    }
 
-        ISomeDependency SomeDependency { get; }
+    ISomeDependency SomeDependency
+    {
+        get;
+    }
 
-        int SomeIntValue { get; }
+    int SomeIntValue
+    {
+        get;
+    }
 
-        string SomeStringValue { get; }
+    string SomeStringValue
+    {
+        get;
     }
 }

--- a/test/Autofac.Extras.AggregateService.Test/IOpenGeneric.cs
+++ b/test/Autofac.Extras.AggregateService.Test/IOpenGeneric.cs
@@ -1,9 +1,8 @@
 ﻿// Copyright (c) Autofac Project. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-namespace Autofac.Extras.AggregateService.Test
+namespace Autofac.Extras.AggregateService.Test;
+
+public interface IOpenGeneric<T>
 {
-    public interface IOpenGeneric<T>
-    {
-    }
 }

--- a/test/Autofac.Extras.AggregateService.Test/IOpenGenericAggregate.cs
+++ b/test/Autofac.Extras.AggregateService.Test/IOpenGenericAggregate.cs
@@ -1,16 +1,15 @@
 ﻿// Copyright (c) Autofac Project. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-namespace Autofac.Extras.AggregateService.Test
+namespace Autofac.Extras.AggregateService.Test;
+
+public interface IOpenGenericAggregate
 {
-    public interface IOpenGenericAggregate
-    {
-        IOpenGeneric<T> GetOpenGeneric<T>();
+    IOpenGeneric<T> GetOpenGeneric<T>();
 
-        IOpenGeneric<string> GetResolvedGeneric();
+    IOpenGeneric<string> GetResolvedGeneric();
 
-        IPassThroughOpenGeneric<T> UseOpenGenericParameter<T>(IOpenGeneric<T> openGeneric);
+    IPassThroughOpenGeneric<T> UseOpenGenericParameter<T>(IOpenGeneric<T> openGeneric);
 
-        IOpenGeneric<T> TooManyParameters<T>(IOpenGeneric<T> a, string b, string c, string d, string e, string f, string g, string h, string i, string j, string k, string l, string m, string n, string o, string p, string q, string r);
-    }
+    IOpenGeneric<T> TooManyParameters<T>(IOpenGeneric<T> a, string b, string c, string d, string e, string f, string g, string h, string i, string j, string k, string l, string m, string n, string o, string p, string q, string r);
 }

--- a/test/Autofac.Extras.AggregateService.Test/IOpenGenericAggregateWithTypeParameter.cs
+++ b/test/Autofac.Extras.AggregateService.Test/IOpenGenericAggregateWithTypeParameter.cs
@@ -1,12 +1,17 @@
 ﻿// Copyright (c) Autofac Project. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-namespace Autofac.Extras.AggregateService.Test
-{
-    public interface IOpenGenericAggregateWithTypeParameter<T>
-    {
-        T SomeProperty { get; }
+namespace Autofac.Extras.AggregateService.Test;
 
-        IOpenGeneric<T> OpenGeneric { get; }
+public interface IOpenGenericAggregateWithTypeParameter<T>
+{
+    T SomeProperty
+    {
+        get;
+    }
+
+    IOpenGeneric<T> OpenGeneric
+    {
+        get;
     }
 }

--- a/test/Autofac.Extras.AggregateService.Test/IPassThroughOpenGeneric.cs
+++ b/test/Autofac.Extras.AggregateService.Test/IPassThroughOpenGeneric.cs
@@ -1,10 +1,12 @@
 ﻿// Copyright (c) Autofac Project. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-namespace Autofac.Extras.AggregateService.Test
+namespace Autofac.Extras.AggregateService.Test;
+
+public interface IPassThroughOpenGeneric<T>
 {
-    public interface IPassThroughOpenGeneric<T>
+    IOpenGeneric<T> OpenGeneric
     {
-        IOpenGeneric<T> OpenGeneric { get; }
+        get;
     }
 }

--- a/test/Autofac.Extras.AggregateService.Test/ISomeDependency.cs
+++ b/test/Autofac.Extras.AggregateService.Test/ISomeDependency.cs
@@ -1,9 +1,8 @@
 ﻿// Copyright (c) Autofac Project. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-namespace Autofac.Extras.AggregateService.Test
+namespace Autofac.Extras.AggregateService.Test;
+
+public interface ISomeDependency
 {
-    public interface ISomeDependency
-    {
-    }
 }

--- a/test/Autofac.Extras.AggregateService.Test/ISomeOtherDependency.cs
+++ b/test/Autofac.Extras.AggregateService.Test/ISomeOtherDependency.cs
@@ -1,9 +1,8 @@
 ﻿// Copyright (c) Autofac Project. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-namespace Autofac.Extras.AggregateService.Test
+namespace Autofac.Extras.AggregateService.Test;
+
+public interface ISomeOtherDependency
 {
-    public interface ISomeOtherDependency
-    {
-    }
 }

--- a/test/Autofac.Extras.AggregateService.Test/ISubService.cs
+++ b/test/Autofac.Extras.AggregateService.Test/ISubService.cs
@@ -1,10 +1,12 @@
 ﻿// Copyright (c) Autofac Project. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-namespace Autofac.Extras.AggregateService.Test
+namespace Autofac.Extras.AggregateService.Test;
+
+public interface ISubService : ISuperService
 {
-    public interface ISubService : ISuperService
+    ISomeOtherDependency SomeOtherDependency
     {
-        ISomeOtherDependency SomeOtherDependency { get; }
+        get;
     }
 }

--- a/test/Autofac.Extras.AggregateService.Test/ISuperService.cs
+++ b/test/Autofac.Extras.AggregateService.Test/ISuperService.cs
@@ -1,10 +1,12 @@
 ﻿// Copyright (c) Autofac Project. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-namespace Autofac.Extras.AggregateService.Test
+namespace Autofac.Extras.AggregateService.Test;
+
+public interface ISuperService
 {
-    public interface ISuperService
+    ISomeDependency SomeDependency
     {
-        ISomeDependency SomeDependency { get; }
+        get;
     }
 }

--- a/test/Autofac.Extras.AggregateService.Test/MyServiceImpl.cs
+++ b/test/Autofac.Extras.AggregateService.Test/MyServiceImpl.cs
@@ -3,49 +3,51 @@
 
 using System;
 
-namespace Autofac.Extras.AggregateService.Test
+namespace Autofac.Extras.AggregateService.Test;
+
+public class MyServiceImpl : IMyService
 {
-    public class MyServiceImpl : IMyService
+    public MyServiceImpl()
     {
-        public MyServiceImpl()
-        {
-        }
+    }
 
-        public MyServiceImpl(int someIntValue)
-        {
-            SomeIntValue = someIntValue;
-        }
+    public MyServiceImpl(int someIntValue)
+    {
+        SomeIntValue = someIntValue;
+    }
 
-        public MyServiceImpl(string someStringValue, ISomeDependency someDependency)
-        {
-            SomeStringValue = someStringValue;
-            SomeDependency = someDependency;
-        }
+    public MyServiceImpl(string someStringValue, ISomeDependency someDependency)
+    {
+        SomeStringValue = someStringValue;
+        SomeDependency = someDependency;
+    }
 
-        public MyServiceImpl(DateTime someDate, int someInt, ISomeDependency someDependency)
-        {
-            SomeDateValue = someDate;
-            SomeIntValue = someInt;
-            SomeDependency = someDependency;
-        }
+    public MyServiceImpl(DateTime someDate, int someInt, ISomeDependency someDependency)
+    {
+        SomeDateValue = someDate;
+        SomeIntValue = someInt;
+        SomeDependency = someDependency;
+    }
 
-        public int SomeIntValue
-        {
-            get;
-            private set;
-        }
+    public int SomeIntValue
+    {
+        get;
+        private set;
+    }
 
-        public string SomeStringValue
-        {
-            get;
-            private set;
-        }
+    public string SomeStringValue
+    {
+        get;
+        private set;
+    }
 
-        public DateTime SomeDateValue
-        {
-            get; private set;
-        }
+    public DateTime SomeDateValue
+    {
+        get; private set;
+    }
 
-        public ISomeDependency SomeDependency { get; private set; }
+    public ISomeDependency SomeDependency
+    {
+        get; private set;
     }
 }

--- a/test/Autofac.Extras.AggregateService.Test/OpenGenericImpl.cs
+++ b/test/Autofac.Extras.AggregateService.Test/OpenGenericImpl.cs
@@ -1,9 +1,8 @@
 ﻿// Copyright (c) Autofac Project. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-namespace Autofac.Extras.AggregateService.Test
+namespace Autofac.Extras.AggregateService.Test;
+
+public class OpenGenericImpl<T> : IOpenGeneric<T>
 {
-    public class OpenGenericImpl<T> : IOpenGeneric<T>
-    {
-    }
 }

--- a/test/Autofac.Extras.AggregateService.Test/PassThroughOpenGenericImpl.cs
+++ b/test/Autofac.Extras.AggregateService.Test/PassThroughOpenGenericImpl.cs
@@ -1,15 +1,17 @@
 ﻿// Copyright (c) Autofac Project. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-namespace Autofac.Extras.AggregateService.Test
-{
-    public class PassThroughOpenGenericImpl<T> : IPassThroughOpenGeneric<T>
-    {
-        public PassThroughOpenGenericImpl(IOpenGeneric<T> openGeneric)
-        {
-            OpenGeneric = openGeneric;
-        }
+namespace Autofac.Extras.AggregateService.Test;
 
-        public IOpenGeneric<T> OpenGeneric { get; }
+public class PassThroughOpenGenericImpl<T> : IPassThroughOpenGeneric<T>
+{
+    public PassThroughOpenGenericImpl(IOpenGeneric<T> openGeneric)
+    {
+        OpenGeneric = openGeneric;
+    }
+
+    public IOpenGeneric<T> OpenGeneric
+    {
+        get;
     }
 }


### PR DESCRIPTION
## Summary

- Standardize `.pre-commit-config.yaml`, `.editorconfig`, `build/stylecop.json`, `build/Source.ruleset`, `build/Test.ruleset` to match Autofac core
- Update `default.proj` Package target to pack individual projects
- Apply `dotnet format` code formatting

## Test plan

- [ ] CI build passes
- [ ] All tests pass
- [ ] `pre-commit run --all-files` passes