### PR TITLE
Update dependencies (Autofac 9.3.1)

### DIFF
--- a/default.proj
+++ b/default.proj
@@ -2,7 +2,7 @@
 <Project DefaultTargets="All" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="Current">
   <PropertyGroup>
     <!-- Increment the overall semantic version here. -->
-    <Version>7.0.0</Version>
+    <Version>7.0.1</Version>
     <SolutionName>Autofac.Extras.AggregateService</SolutionName>
     <Configuration Condition="'$(Configuration)'==''">Release</Configuration>
     <ArtifactDirectory>$([System.IO.Path]::Combine($(MSBuildProjectDirectory),"artifacts"))</ArtifactDirectory>

--- a/src/Autofac.Extras.AggregateService.SourceGenerator/Autofac.Extras.AggregateService.SourceGenerator.csproj
+++ b/src/Autofac.Extras.AggregateService.SourceGenerator/Autofac.Extras.AggregateService.SourceGenerator.csproj
@@ -60,7 +60,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="[4.14.0]">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.27.0.140913">
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.28.0.143324">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/Autofac.Extras.AggregateService/Autofac.Extras.AggregateService.csproj
+++ b/src/Autofac.Extras.AggregateService/Autofac.Extras.AggregateService.csproj
@@ -66,12 +66,12 @@
     <AdditionalFiles Include="../../build/stylecop.json" Link="stylecop.json" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Autofac" Version="9.3.0" />
+    <PackageReference Include="Autofac" Version="9.3.1" />
     <PackageReference Include="Castle.Core" Version="5.2.1" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.300" Condition="Exists('$(MSBuildThisFileDirectory)../../.git')">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.27.0.140913">
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.28.0.143324">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
@@ -86,9 +86,7 @@
     Microsoft.CodeAnalysis off this library's reference and runtime closure.
   -->
   <ItemGroup>
-    <ProjectReference Include="..\Autofac.Extras.AggregateService.SourceGenerator\Autofac.Extras.AggregateService.SourceGenerator.csproj"
-                      OutputItemType="Analyzer"
-                      ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\Autofac.Extras.AggregateService.SourceGenerator\Autofac.Extras.AggregateService.SourceGenerator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
   </ItemGroup>
   <!--
     Pack the generator assembly into the package's analyzers/dotnet/cs folder so
@@ -99,17 +97,12 @@
     build fails loudly if the assembly is missing instead of packing nothing.
   -->
   <Target Name="IncludeSourceGeneratorInPackage" BeforeTargets="_GetPackageFiles">
-    <MSBuild Projects="..\Autofac.Extras.AggregateService.SourceGenerator\Autofac.Extras.AggregateService.SourceGenerator.csproj"
-             Targets="GetTargetPath">
+    <MSBuild Projects="..\Autofac.Extras.AggregateService.SourceGenerator\Autofac.Extras.AggregateService.SourceGenerator.csproj" Targets="GetTargetPath">
       <Output TaskParameter="TargetOutputs" ItemName="_SourceGeneratorAssembly" />
     </MSBuild>
-    <Error Condition="'@(_SourceGeneratorAssembly)' == '' or !Exists('%(_SourceGeneratorAssembly.Identity)')"
-           Text="The source generator assembly was not found at '@(_SourceGeneratorAssembly)'. Build the solution before packing so the generator is packed into analyzers/dotnet/cs." />
+    <Error Condition="'@(_SourceGeneratorAssembly)' == '' or !Exists('%(_SourceGeneratorAssembly.Identity)')" Text="The source generator assembly was not found at '@(_SourceGeneratorAssembly)'. Build the solution before packing so the generator is packed into analyzers/dotnet/cs." />
     <ItemGroup>
-      <None Include="@(_SourceGeneratorAssembly)"
-            Pack="true"
-            PackagePath="analyzers/dotnet/cs"
-            Visible="false" />
+      <None Include="@(_SourceGeneratorAssembly)" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
     </ItemGroup>
   </Target>
   <ItemDefinitionGroup>

--- a/test/Autofac.Extras.AggregateService.SourceGenerator.Test/Autofac.Extras.AggregateService.SourceGenerator.Test.csproj
+++ b/test/Autofac.Extras.AggregateService.SourceGenerator.Test/Autofac.Extras.AggregateService.SourceGenerator.Test.csproj
@@ -46,8 +46,8 @@
       matching Microsoft.CodeAnalysis.CSharp version.
     -->
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="[4.14.0]" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.27.0.140913">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.28.0.143324">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
@@ -56,7 +56,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Verify.SourceGenerators" Version="2.5.0" />
-    <PackageReference Include="Verify.Xunit" Version="31.7.1" />
+    <PackageReference Include="Verify.Xunit" Version="31.12.5" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>

--- a/test/Autofac.Extras.AggregateService.Test/Autofac.Extras.AggregateService.Test.csproj
+++ b/test/Autofac.Extras.AggregateService.Test/Autofac.Extras.AggregateService.Test.csproj
@@ -23,9 +23,7 @@
     <!-- Reference the generator as an analyzer so the test project exercises the generated path
          exactly as a real package consumer would (a ProjectReference does not transitively flow
          analyzers; the NuGet analyzers/dotnet/cs folder does that for package consumers). -->
-    <ProjectReference Include="..\..\src\Autofac.Extras.AggregateService.SourceGenerator\Autofac.Extras.AggregateService.SourceGenerator.csproj"
-                      OutputItemType="Analyzer"
-                      ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\src\Autofac.Extras.AggregateService.SourceGenerator\Autofac.Extras.AggregateService.SourceGenerator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
   </ItemGroup>
   <ItemGroup>
     <AdditionalFiles Include="../../build/stylecop.json" Link="stylecop.json" />
@@ -39,9 +37,9 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
     <PackageReference Include="NSubstitute" Version="5.3.0" />
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.27.0.140913">
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.28.0.143324">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
## Summary

- Updated Autofac from 9.3.0 to 9.3.1 (src)
- Updated SonarAnalyzer.CSharp from 10.27.0.140913 to 10.28.0.143324 (src + test, analyzer/private assets only)
- Updated Microsoft.NET.Test.Sdk from 18.6.0 to 18.7.0 (test only)
- Updated Verify.Xunit from 31.7.1 to 31.12.5 (test only)
- Bumped package version from 7.0.0 to 7.0.1

## Test plan

- [ ] CI build passes
- [ ] All unit tests pass
- [ ] No new warnings in Release build